### PR TITLE
Fix typo (templetized => templatized) in Frozen.h

### DIFF
--- a/thrift/lib/cpp/Frozen.h
+++ b/thrift/lib/cpp/Frozen.h
@@ -477,7 +477,7 @@ struct RangeFreezer {
 
 /**
  * FrozenMap<...> - Wraps a sorted FrozenRange<K, V> with the expected
- * interface for a map. find() and others are templetized to allow searching for
+ * interface for a map. find() and others are templatized to allow searching for
  * values of any type which may be compared to the key, though may not be of
  * type K.
  */


### PR DESCRIPTION
- http://en.wiktionary.org/wiki/templatize
- "templatized C++" has ~300,000 Google results, "templetized C++" has O(1,500) results.
