### PR TITLE
Update CppClient.cpp

### DIFF
--- a/thrift/tutorial/cpp/CppClient.cpp
+++ b/thrift/tutorial/cpp/CppClient.cpp
@@ -38,9 +38,9 @@ using namespace shared;
 using namespace boost;
 
 int main(int argc, char** argv) {
-  std::shared_ptr<TTransport> socket(new TSocket("localhost", 9090));
-  std::shared_ptr<TTransport> transport(new TBufferedTransport(socket));
-  std::shared_ptr<TProtocol> protocol(new TBinaryProtocol(transport));
+  std::shared_ptr<TTransport> socket{std::make_shared<TSocket>("localhost", 9090)};
+  std::shared_ptr<TTransport> transport{std::make_shared<TBufferedTransport>(socket)};
+  std::shared_ptr<TProtocol> protocol{std::make_shared<TBinaryProtocol>(transport)};
   CalculatorClient client(protocol);
 
   try {


### PR DESCRIPTION
Fixed initialization of the objects of type `std::shared_ptr`. Raw `new` results in a suboptimal allocation pattern (and is potentially exception-unsafe) -- `std::make_shared` is the recommended practice when using `std::shared_ptr`, see:
- http://en.cppreference.com/w/cpp/memory/shared_ptr/make_shared
- http://channel9.msdn.com/Events/GoingNative/GoingNative-2012/STL11-Magic-Secrets
- http://blog.emptycrate.com/node/474
- http://channel9.msdn.com/Series/C9-Lectures-Stephan-T-Lavavej-Standard-Template-Library-STL-/C9-Lectures-Stephan-T-Lavavej-Standard-Template-Library-STL-3-of-n
