### PR TITLE
Disable zipping of the egg file to allow loading of frontend.so

### DIFF
--- a/thrift/compiler/py/setup.py
+++ b/thrift/compiler/py/setup.py
@@ -33,6 +33,7 @@ def run_setup():
             'Topic :: Software Development :: Libraries',
             'Topic :: System :: Networking'
         ],
+        zip_safe = False,
     )
 
 run_setup()


### PR DESCRIPTION
Installation of the thrift compiler as a zipped egg would not work on Ubuntu
14.04 as frontend.so was not being loaded. Disabling zip resolves the problem
without requiring users to specify -Z when installing the package.
