### PR TITLE
build fails when python3 is default python

### DIFF
--- a/thrift/lib/cpp2/Makefile.am
+++ b/thrift/lib/cpp2/Makefile.am
@@ -147,7 +147,7 @@ BUILT_SOURCES = gen-cpp2/Sasl_constants.cpp \
 		gen-cpp2/SaslAuthService_client.cpp
 
 gen-cpp2/Sasl_types.h: Sasl.thrift
-	PYTHONPATH=$(PY_LOCAL_PATH) python -mthrift_compiler.main --gen cpp2 $<
+	PYTHONPATH=$(PY_LOCAL_PATH) $(PYTHON) -mthrift_compiler.main --gen cpp2 $<
 
 gen-cpp2/Sasl_constants.cpp: gen-cpp2/Sasl_types.h
 


### PR DESCRIPTION
Build fails when python3 is default python (for example ArchLinux).
$ python -V
python 3.4.3
$ python2 -V
python 2.7.9
#--
$ autoreconf -ivf
$ PYTHON=/usr/bin/python2 ./configure --prefix=/usr --disable-static
$ make
(...)
Making all in cpp2
make[3]: Entering directory '/tmp/fbthrift-0.24.0/thrift/lib/cpp2'
PYTHONPATH=../../.python-local/lib/python python -mthrift_compiler.main --gen cpp2 Sasl.thrift
/usr/bin/python: Error while finding spec for 'thrift_compiler.main' (<class 'ImportError'>: No module named 'generate')
Makefile:1801: recipe for target 'gen-cpp2/Sasl_types.h' failed
make[3]: *** [gen-cpp2/Sasl_types.h] Error 1
make[3]: Leaving directory '/tmp/fbthrift-0.24.0/thrift/lib/cpp2'
Makefile:445: recipe for target 'all-recursive' failed
make[2]: *** [all-recursive] Error 1
make[2]: Leaving directory '/tmp/fbthrift-0.24.0/thrift/lib'
Makefile:526: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/tmp/fbthrift-0.24.0/thrift'
Makefile:458: recipe for target 'all' failed
make: *** [all] Error 2
