### PR TITLE
Bump required folly version and match inclusion flags

### DIFF
--- a/thrift/configure.ac
+++ b/thrift/configure.ac
@@ -549,7 +549,7 @@ fi
 # --- Coverage hooks ---
 
 
-AC_SUBST(AM_CPPFLAGS, '-I$(top_srcdir)/..'" $CXX_FLAGS $BOOST_CPPFLAGS")
+AC_SUBST(AM_CPPFLAGS, '-I$(top_srcdir)/.. -I$(top_srcdir)/folly'" $CXX_FLAGS $BOOST_CPPFLAGS")
 
 AC_SUBST(PY_LOCAL_ROOT, '$(top_builddir)/.python-local')
 AC_SUBST(PY_LOCAL_PATH, '$(PY_LOCAL_ROOT)/lib/python')

--- a/thrift/deps.sh
+++ b/thrift/deps.sh
@@ -7,7 +7,7 @@ cd "$(dirname ${0})"
 git clone https://github.com/facebook/folly
 cd folly/folly
 git fetch
-git checkout v0.32.0
+git checkout v0.37.0
 
 autoreconf --install
 ./configure


### PR DESCRIPTION
The current open source build plan checks out an older than compatible version of folly. The include directives do not match the checkout directory.