### PR TITLE
Use std::unordered_map rather than ext/hash_map in TEventWorker

### DIFF
--- a/thrift/lib/cpp/async/TEventWorker.h
+++ b/thrift/lib/cpp/async/TEventWorker.h
@@ -24,10 +24,9 @@
 #include <thrift/lib/cpp/async/TEventTask.h>
 #include <thrift/lib/cpp/async/TEventHandler.h>
 #include <thrift/lib/cpp/async/TNotificationQueue.h>
-#include <thrift/lib/cpp/server/TServer.h>
-#include <ext/hash_map>
 #include <list>
 #include <stack>
+#include <unordered_map>
 
 namespace apache { namespace thrift { namespace async {
 
@@ -125,9 +124,9 @@ class TEventWorker :
         return ((size_t)p ^ ((size_t)p >> kPtrHashShift)) * kPtrHashMult;
       }
     };
-  typedef __gnu_cxx::hash_map<const TEventConnection*,
+  typedef std::unordered_map<const TEventConnection*,
                               ConnectionList::iterator,
-                              hash<TEventConnection*> > ConnectionMap;
+                              hash<TEventConnection*>> ConnectionMap;
 
   /**
    * The list of active connections (used to allow the oldest connections


### PR DESCRIPTION
Because `ext/hash_map` is a GCC specific extension, which MSVC doesn't implement. (well, it does, but it's deprecated) `std::unordered_map` has the same functionality, and is part of the standard library, so use it instead.