### PR TITLE
Construct default functions by passing nothing rather than 0

### DIFF
--- a/thrift/lib/cpp/concurrency/FunctionRunner.h
+++ b/thrift/lib/cpp/concurrency/FunctionRunner.h
@@ -81,7 +81,7 @@ class FunctionRunner : public Runnable {
    * execute the given callback.  Note that the 'void*' return value is ignored.
    */
   FunctionRunner(PthreadFuncPtr func, void* arg)
-   : func_([=]{ func(arg); }), repFunc_(0), initFunc_(0)
+   : func_([=]{ func(arg); }), repFunc_(), initFunc_()
   { }
 
   /**
@@ -89,7 +89,7 @@ class FunctionRunner : public Runnable {
    */
   template <class F>
   explicit FunctionRunner(F&& cob)
-   : func_(std::forward<F>(cob)), repFunc_(0), initFunc_(0)
+   : func_(std::forward<F>(cob)), repFunc_(), initFunc_()
   { }
 
   /**
@@ -100,8 +100,8 @@ class FunctionRunner : public Runnable {
    */
   template <class F>
   FunctionRunner(F&& cob, int intervalMs)
-   : func_(0), repFunc_(std::forward<F>(cob)), intervalMs_(intervalMs),
-     initFunc_(0)
+   : func_(), repFunc_(std::forward<F>(cob)), intervalMs_(intervalMs),
+     initFunc_()
   {
     if (intervalMs_ < 0) {
       throw InvalidArgumentException();


### PR DESCRIPTION
Because MSVC's implementation of `std::function` is really not a big fan of passing in `0`, more specifically, it errors at the end of a 15 deep template chain. Constructing it by passing nothing solves the problem.