### PR TITLE
Support platforms where pthread_t is a struct

### DIFF
--- a/thrift/lib/cpp/concurrency/PosixThreadFactory.cpp
+++ b/thrift/lib/cpp/concurrency/PosixThreadFactory.cpp
@@ -74,7 +74,7 @@ bool PthreadThread::updateName() {
 PthreadThread::PthreadThread(int policy, int priority, int stackSize,
                              bool detached,
                              shared_ptr<Runnable> runnable) :
-  pthread_(0),
+  pthread_(pthread_t_init),
   state_(uninitialized),
   policy_(policy),
   priority_(priority),
@@ -162,7 +162,11 @@ void PthreadThread::join() {
 }
 
 Thread::id_t PthreadThread::getId() {
+#ifdef _MSC_VER
+  return (Thread::id_t)pthread_getw32threadid_np(pthread_);
+#else
   return (Thread::id_t)pthread_;
+#endif
 }
 
 shared_ptr<Runnable> PthreadThread::runnable() const {
@@ -312,7 +316,11 @@ void PosixThreadFactory::Impl::setDetachState(DetachState value) {
 }
 
 Thread::id_t PosixThreadFactory::Impl::getCurrentThreadId() const {
+#ifdef _MSC_VER
+  return (Thread::id_t)pthread_getw32threadid_np(pthread_self());
+#else
   return (Thread::id_t)pthread_self();
+#endif
 }
 
 

--- a/thrift/lib/cpp/concurrency/PosixThreadFactory.cpp
+++ b/thrift/lib/cpp/concurrency/PosixThreadFactory.cpp
@@ -74,7 +74,7 @@ bool PthreadThread::updateName() {
 PthreadThread::PthreadThread(int policy, int priority, int stackSize,
                              bool detached,
                              shared_ptr<Runnable> runnable) :
-  pthread_(pthread_t_init),
+  pthread_(pthread_zero),
   state_(uninitialized),
   policy_(policy),
   priority_(priority),

--- a/thrift/lib/cpp/transport/TFileTransport.cpp
+++ b/thrift/lib/cpp/transport/TFileTransport.cpp
@@ -83,7 +83,7 @@ TFileTransport::TFileTransport(string path, bool readOnly)
   , maxCorruptedEvents_(DEFAULT_MAX_CORRUPTED_EVENTS)
   , eofSleepTime_(DEFAULT_EOF_SLEEP_TIME_US)
   , writerThreadIOErrorSleepTime_(DEFAULT_WRITER_THREAD_SLEEP_TIME_US)
-  , writerThreadId_(pthread_t_init)
+  , writerThreadId_(pthread_zero)
   , dequeueBuffer_(nullptr)
   , enqueueBuffer_(nullptr)
   , closing_(false)
@@ -146,7 +146,7 @@ TFileTransport::~TFileTransport() {
     pthread_mutex_unlock(&mutex_);
 
     pthread_join(writerThreadId_, nullptr);
-    writerThreadId_ = pthread_t_init;
+    writerThreadId_ = pthread_zero;
   }
 
   if (dequeueBuffer_) {


### PR DESCRIPTION
Such as on Windows.

Note that this requires [folly #285](https://github.com/facebook/folly/pull/285) to have been merged upstream before this will compile properly.
