### PR TITLE
Construct timeval in a way that MSVC likes

### DIFF
--- a/thrift/lib/cpp/util/PausableTimer.cpp
+++ b/thrift/lib/cpp/util/PausableTimer.cpp
@@ -30,8 +30,8 @@ PausableTimer::PausableTimer(int timeLimit) {
 
 void PausableTimer::reset() {
   if (isTimeLimitFinite_) {
-    totalTimed_ = (struct timeval){ 0 };
-    lastRunningTime_ = (struct timeval){ 0 };
+    totalTimed_ = timeval{ 0 };
+    lastRunningTime_ = timeval{ 0 };
     paused_ = true;
   }
 }


### PR DESCRIPTION
MSVC doesn't like it when you try to construct a struct by surrounding the type name with perenthesis, so remove the parenthesis and the unneeded struct keyword.