### PR TITLE
Disable a couple of things under MSVC

### DIFF
--- a/thrift/lib/cpp/async/TEventServer.cpp
+++ b/thrift/lib/cpp/async/TEventServer.cpp
@@ -122,8 +122,10 @@ void TEventServer::setupServerSocket() {
   bool eventBaseAttached = false;
 
   try {
+#ifndef _MSC_VER
     // We check for write success so we don't need or want SIGPIPEs.
     signal(SIGPIPE, sigNoOp);
+#endif
 
     // bind to the socket
     if (!socket_) {

--- a/thrift/lib/cpp/concurrency/PosixThreadFactory.cpp
+++ b/thrift/lib/cpp/concurrency/PosixThreadFactory.cpp
@@ -209,10 +209,12 @@ void* PthreadThread::threadMain(void* arg) {
         err, strerror(err);
     }
   } else if (thread->policy_ == SCHED_OTHER) {
+#ifndef _MSC_VER
     if (setpriority(PRIO_PROCESS, 0, thread->priority_) != 0) {
       VLOG(1) << "setpriority failed (are you root?) with error " <<
         errno, strerror(errno);
     }
+#endif
   }
 
   thread->runnable()->run();


### PR DESCRIPTION
As there is no `SIGPIPE` in MSVC, there is no need to handle it.
This also disables setting the priority of the process purely because it's not necessary to work, but does need to be disabled in order to compile.