### PR TITLE
Disable an __attribute__((__unused__)) under MSVC

### DIFF
--- a/thrift/lib/cpp/concurrency/ThreadManager.tcc
+++ b/thrift/lib/cpp/concurrency/ThreadManager.tcc
@@ -202,7 +202,10 @@ void ThreadManager::ImplT<SemType>::workerExiting(Worker<SemType>* worker) {
   Guard g(mutex_);
 
   shared_ptr<Thread> thread = worker->thread();
-  __attribute__((__unused__)) size_t numErased = idMap_.erase(thread->getId());
+#ifndef _MSC_VER
+  __attribute__((__unused__))
+#endif
+  size_t numErased = idMap_.erase(thread->getId());
   assert(numErased == 1);
 
   --workerCount_;


### PR DESCRIPTION
Because `__attribute__` isn't supported by MSVC.