### PR TITLE
Adjust the includes for MSVC with Folly

### DIFF
--- a/thrift/lib/cpp/Thrift.h
+++ b/thrift/lib/cpp/Thrift.h
@@ -28,7 +28,7 @@
 #ifdef THRIFT_HAVE_INTTYPES_H
 #include <inttypes.h>
 #endif
-#include <netinet/in.h>
+#include <folly/SocketPortability.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/thrift/lib/cpp/async/TAsyncTransport.h
+++ b/thrift/lib/cpp/async/TAsyncTransport.h
@@ -22,7 +22,7 @@
 #include <thrift/lib/cpp/transport/TTransportException.h>
 #include <folly/io/async/AsyncSocket.h>
 #include <thrift/lib/cpp/thrift_config.h>
-#include <sys/uio.h>
+#include <folly/FilePortability.h>
 #include <inttypes.h>
 #include <memory>
 

--- a/thrift/lib/cpp/async/TEventServer.cpp
+++ b/thrift/lib/cpp/async/TEventServer.cpp
@@ -25,14 +25,12 @@
 #include <boost/thread/barrier.hpp>
 
 #include <iostream>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <netdb.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <assert.h>
 #include <signal.h>
+
+#include <folly/SocketPortability.h>
 
 namespace apache { namespace thrift { namespace async {
 

--- a/thrift/lib/cpp/async/TEventWorker.cpp
+++ b/thrift/lib/cpp/async/TEventWorker.cpp
@@ -24,14 +24,12 @@
 #include <thrift/lib/cpp/concurrency/Util.h>
 
 #include <iostream>
-#include <sys/socket.h>
-#include <sys/uio.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <netdb.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <assert.h>
+
+#include <folly/FilePortability.h>
+#include <folly/SocketPortability.h>
 
 namespace apache { namespace thrift { namespace async {
 

--- a/thrift/lib/cpp/concurrency/FunctionRunner.h
+++ b/thrift/lib/cpp/concurrency/FunctionRunner.h
@@ -17,7 +17,7 @@
 #ifndef _THRIFT_CONCURRENCY_FUNCTION_RUNNER_H
 #define _THRIFT_CONCURRENCY_FUNCTION_RUNNER_H 1
 
-#include <unistd.h>
+#include <folly/FilePortability.h>
 #include <functional>
 #include <thrift/lib/cpp/concurrency/Monitor.h>
 #include <thrift/lib/cpp/concurrency/Thread.h>

--- a/thrift/lib/cpp/concurrency/PosixThreadFactory.cpp
+++ b/thrift/lib/cpp/concurrency/PosixThreadFactory.cpp
@@ -25,8 +25,7 @@
 
 #include <assert.h>
 #include <pthread.h>
-#include <sys/resource.h>
-
+#include <folly/CPortability.h>
 #include <iostream>
 
 #include <glog/logging.h>

--- a/thrift/lib/cpp/concurrency/ThreadManager.h
+++ b/thrift/lib/cpp/concurrency/ThreadManager.h
@@ -18,12 +18,12 @@
 #define _THRIFT_CONCURRENCY_THREADMANAGER_H_ 1
 
 #include <sys/types.h>
-#include <unistd.h>
 
 #include <array>
 #include <functional>
 #include <memory>
 
+#include <folly/FilePortability.h>
 #include <folly/Executor.h>
 #include <folly/LifoSem.h>
 #include <folly/RWSpinLock.h>

--- a/thrift/lib/cpp/concurrency/Util.cpp
+++ b/thrift/lib/cpp/concurrency/Util.cpp
@@ -24,7 +24,7 @@
 #if defined(THRIFT_HAVE_CLOCK_GETTIME)
 #include <time.h>
 #elif defined(THRIFT_HAVE_GETTIMEOFDAY)
-#include <sys/time.h>
+#include <folly/CPortability.h>
 #endif // defined(THRIFT_HAVE_CLOCK_GETTIME)
 #include <errno.h>
 #include <assert.h>

--- a/thrift/lib/cpp/concurrency/Util.h
+++ b/thrift/lib/cpp/concurrency/Util.h
@@ -24,7 +24,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <time.h>
-#include <sys/time.h>
+#include <folly/CPortability.h>
 #include <chrono>
 
 namespace apache { namespace thrift { namespace concurrency {

--- a/thrift/lib/cpp/protocol/TProtocol.h
+++ b/thrift/lib/cpp/protocol/TProtocol.h
@@ -25,7 +25,7 @@
 
 #include <memory>
 
-#include <netinet/in.h>
+#include <folly/SocketPortability.h>
 #include <sys/types.h>
 #include <string>
 #include <map>

--- a/thrift/lib/cpp/server/TServer.cpp
+++ b/thrift/lib/cpp/server/TServer.cpp
@@ -17,9 +17,8 @@
  * under the License.
  */
 
-#include <sys/time.h>
-#include <sys/resource.h>
-#include <unistd.h>
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
 
 namespace apache { namespace thrift { namespace server {
 

--- a/thrift/lib/cpp/transport/TFDTransport.cpp
+++ b/thrift/lib/cpp/transport/TFDTransport.cpp
@@ -22,7 +22,7 @@
 #include <cerrno>
 #include <exception>
 
-#include <unistd.h>
+#include <folly/FilePortability.h>
 
 using namespace std;
 

--- a/thrift/lib/cpp/transport/TFDTransport.h
+++ b/thrift/lib/cpp/transport/TFDTransport.h
@@ -21,7 +21,7 @@
 #define _THRIFT_TRANSPORT_TFDTRANSPORT_H_ 1
 
 #include <string>
-#include <sys/time.h>
+#include <folly/CPortability.h>
 
 #include <thrift/lib/cpp/transport/TTransport.h>
 #include <thrift/lib/cpp/transport/TVirtualTransport.h>

--- a/thrift/lib/cpp/transport/TFileTransport.cpp
+++ b/thrift/lib/cpp/transport/TFileTransport.cpp
@@ -31,7 +31,7 @@
 #endif
 #include <fcntl.h>
 #include <errno.h>
-#include <unistd.h>
+#include <folly/FilePortability.h>
 #ifdef THRIFT_HAVE_STRINGS_H
 #include <strings.h>
 #endif

--- a/thrift/lib/cpp/transport/THeader.h
+++ b/thrift/lib/cpp/transport/THeader.h
@@ -25,8 +25,7 @@
 #include <thrift/lib/cpp/concurrency/Thread.h>
 
 #include <bitset>
-#include <pwd.h>
-#include <unistd.h>
+#include <folly/FilePortability.h>
 #include <chrono>
 
 // Don't include the unknown client.

--- a/thrift/lib/cpp/transport/THeaderTransport.h
+++ b/thrift/lib/cpp/transport/THeaderTransport.h
@@ -35,8 +35,7 @@
 
 #include <bitset>
 #include <boost/scoped_array.hpp>
-#include <pwd.h>
-#include <unistd.h>
+#include <folly/FilePortability.h>
 
 namespace apache { namespace thrift { namespace transport {
 

--- a/thrift/lib/cpp/transport/TSSLSocket.cpp
+++ b/thrift/lib/cpp/transport/TSSLSocket.cpp
@@ -16,10 +16,10 @@
 
 #include <thrift/lib/cpp/transport/TSSLSocket.h>
 
-#include <arpa/inet.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/scoped_array.hpp>
 #include <errno.h>
+#include <folly/SocketPortability.h>
 #include <folly/String.h>
 #include <glog/logging.h>
 #include <openssl/err.h>

--- a/thrift/lib/cpp/transport/TSocket.h
+++ b/thrift/lib/cpp/transport/TSocket.h
@@ -18,7 +18,7 @@
 #define _THRIFT_TRANSPORT_TSOCKET_H_ 1
 
 #include <string>
-#include <sys/time.h>
+#include <folly/CPortability.h>
 
 #include <thrift/lib/cpp/transport/TRpcTransport.h>
 #include <thrift/lib/cpp/transport/TVirtualTransport.h>

--- a/thrift/lib/cpp/util/FdUtils.cpp
+++ b/thrift/lib/cpp/util/FdUtils.cpp
@@ -20,6 +20,7 @@
 #include <thrift/lib/cpp/util/FdUtils.h>
 
 #include <fcntl.h>
+#include <folly/FilePortability.h>
 
 namespace apache { namespace thrift { namespace util {
 

--- a/thrift/lib/cpp/util/PausableTimer.cpp
+++ b/thrift/lib/cpp/util/PausableTimer.cpp
@@ -17,7 +17,8 @@
 #include <thrift/lib/cpp/util/PausableTimer.h>
 
 #include <stdint.h>
-#include <sys/time.h>
+#include <folly/CPortability.h>
+#include <folly/FilePortability.h>
 
 namespace apache { namespace thrift { namespace util {
 

--- a/thrift/lib/cpp/util/PausableTimer.h
+++ b/thrift/lib/cpp/util/PausableTimer.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <stdint.h>
-#include <sys/time.h>
+#include <folly/CPortability.h>
 #include <sys/types.h>
 
 namespace apache { namespace thrift { namespace util {


### PR DESCRIPTION
This adjusts the `#includes` to use Folly's portability headers.
This only adjusts the files being included in all files changed except for `thrift/lib/cpp/transport/TSSLSocket.cpp` and `thrift/lib/cpp/transport/TServerSocket.cpp`, where adjustments were made to call into the socket portability stubs directly to resolve which overload is being called.

This is dependent upon [Folly #287](https://github.com/facebook/folly/pull/287) being merged upstream first.
