### PR TITLE
readme: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ dependencies (like `folly`).
     - autoconf
     - libtool
     - g++
-    - libboost-dev-all
+    - libboost-all-dev
     - libevent-dev
     - flex
     - bison


### PR DESCRIPTION
This is the actual name of the package on Ubuntu 14.04
