### PR TITLE
Include missing input in makefile.

### DIFF
--- a/thrift/lib/cpp2/Makefile.am
+++ b/thrift/lib/cpp2/Makefile.am
@@ -138,6 +138,7 @@ libthriftprotocol_la_SOURCES = Version.cpp \
                                protocol/CompactProtocol.cpp \
                                protocol/DebugProtocol.cpp \
                                protocol/JSONProtocol.cpp \
+                               protocol/JSONProtocolCommon.cpp \
                                protocol/Serializer.cpp \
                                protocol/SimpleJSONProtocol.cpp \
                                protocol/VirtualProtocol.cpp


### PR DESCRIPTION
fboss fails to build without this change, since it's missing the json table.
