### PR TITLE
Added missing cpp to cpp2 makefile

### DIFF
--- a/thrift/lib/cpp2/Makefile.am
+++ b/thrift/lib/cpp2/Makefile.am
@@ -138,6 +138,7 @@ libthriftprotocol_la_SOURCES = Version.cpp \
                                protocol/CompactProtocol.cpp \
                                protocol/DebugProtocol.cpp \
                                protocol/JSONProtocol.cpp \
+                               protocol/JSONProtocolCommon.cpp \
                                protocol/Serializer.cpp \
                                protocol/SimpleJSONProtocol.cpp \
                                protocol/VirtualProtocol.cpp


### PR DESCRIPTION
There was a recent change to add JSONProtocolCommon to the build:
https://github.com/facebook/fbthrift/commit/81ba8307e5a97f0fb413264917230ed0fb93ad54
And I guess there is an additional change needed to that makefile.

I'm currently seeing issues when linking the fbthrift library to fboss:

`
Linking CXX executable wedge_agent
libfboss_agent.a(Address_types.cpp.o): In function apache::thrift::JSONProtocolWriterCommon::writeJSONChar(unsigned char)':
Address_types.cpp(.text._ZN6apache6thrift24JSONProtocolWriterCommon13writeJSONCharEh[_ZN6apache6thrift24JSONProtocolWriterCommon13writeJSONCharEh]+0x7f): undefined reference to apache::thrift::JSONProtocolWriterCommon::kJSONCharTable'
`

This pull request seems to resolve that link issue.