### PR TITLE
To compare two string as lowercase.

### DIFF
--- a/thrift/lib/d/thrift/transport/http.d
+++ b/thrift/lib/d/thrift/transport/http.d
@@ -134,7 +134,7 @@ protected:
     }
 
     static bool compToLower(ubyte a, ubyte b) {
-      return a == toLower(cast(char)b);
+      return toLower(cast(char)a) == toLower(cast(char)b);
     }
 
     if (startsWith!compToLower(split[0], cast(ubyte[])"transfer-encoding")) {


### PR DESCRIPTION
it looks unexpected result got when parameter a is uppercase and b is lowercase.
split[0] is string of 'Content-Length', it contains character with uppercase.