### PR TITLE
Fixing missing includes for compilation under CentOS

### DIFF
--- a/thrift/lib/cpp/util/kerberos/Krb5CredentialsCacheManager.cpp
+++ b/thrift/lib/cpp/util/kerberos/Krb5CredentialsCacheManager.cpp
@@ -28,7 +28,8 @@
 #include <folly/String.h>
 
 #ifndef NO_LIB_GFLAGS
-// DO NOT modify this flag from your application
+ #include <gflags/gflags.h>
+ // DO NOT modify this flag from your application
 DEFINE_string(
   thrift_cc_manager_kill_switch_file,
   "/var/thrift_security/disable_cc_manager",

--- a/thrift/lib/cpp/util/kerberos/Krb5Util.cpp
+++ b/thrift/lib/cpp/util/kerberos/Krb5Util.cpp
@@ -27,7 +27,6 @@
 
 #ifndef NO_LIB_GFLAGS
  #include <gflags/gflags.h>
-#endif
 
 DEFINE_string (thrift_krb5_user_instances, "admin,root,sudo",
        "List of possible instances(second component) of "

--- a/thrift/lib/cpp/util/kerberos/Krb5Util.cpp
+++ b/thrift/lib/cpp/util/kerberos/Krb5Util.cpp
@@ -27,6 +27,7 @@
 
 #ifndef NO_LIB_GFLAGS
  #include <gflags/gflags.h>
+#endif
 
 DEFINE_string (thrift_krb5_user_instances, "admin,root,sudo",
        "List of possible instances(second component) of "

--- a/thrift/lib/cpp/util/kerberos/Krb5Util.cpp
+++ b/thrift/lib/cpp/util/kerberos/Krb5Util.cpp
@@ -26,6 +26,8 @@
 #include <thrift/lib/cpp/util/kerberos/FBKrb5GetCreds.h>
 
 #ifndef NO_LIB_GFLAGS
+ #include <gflags/gflags.h>
+
 DEFINE_string (thrift_krb5_user_instances, "admin,root,sudo",
        "List of possible instances(second component) of "
        "user kerberos credentials. Separated by ','. ");

--- a/thrift/lib/cpp2/protocol/BinaryProtocol.h
+++ b/thrift/lib/cpp2/protocol/BinaryProtocol.h
@@ -25,6 +25,7 @@
 
 #ifndef NO_LIB_GFLAGS
  #include <gflags/gflags.h>
+#endif
 
 #ifndef NO_LIB_GFLAGS
 DECLARE_int32(thrift_cpp2_protocol_reader_string_limit);

--- a/thrift/lib/cpp2/protocol/BinaryProtocol.h
+++ b/thrift/lib/cpp2/protocol/BinaryProtocol.h
@@ -24,6 +24,9 @@
 #include <thrift/lib/cpp2/protocol/Protocol.h>
 
 #ifndef NO_LIB_GFLAGS
+ #include <gflags/gflags.h>
+
+#ifndef NO_LIB_GFLAGS
 DECLARE_int32(thrift_cpp2_protocol_reader_string_limit);
 DECLARE_int32(thrift_cpp2_protocol_reader_container_limit);
 #else


### PR DESCRIPTION
gflags includes were missing in 3 files, now it compiles all smoothly on centos.
Closes the issue #146 