### PR TITLE
Adding missing gflags includes and fixing Makefile

### DIFF
--- a/thrift/lib/cpp2/Makefile.am
+++ b/thrift/lib/cpp2/Makefile.am
@@ -40,6 +40,7 @@ thrift2includedir = $(includedir)/thrift/lib/cpp2
 thrift2include_HEADERS = \
 	Thrift.h \
 	GeneratedCodeHelper.h \
+	GeneratedHeaderHelper.h \
 	ServiceIncludes.h \
 	CloneableIOBuf.h
 

--- a/thrift/lib/cpp2/async/PcapLoggingHandler.cpp
+++ b/thrift/lib/cpp2/async/PcapLoggingHandler.cpp
@@ -28,6 +28,7 @@
 #include <time.h>
 #include <stdlib.h>
 #include <fcntl.h>
+#include <gflags/gflags.h>
 
 // For reallllly old systems, sigh
 #ifndef O_CLOEXEC

--- a/thrift/lib/cpp2/security/SecurityKillSwitchPoller.cpp
+++ b/thrift/lib/cpp2/security/SecurityKillSwitchPoller.cpp
@@ -18,6 +18,8 @@
 #include <thrift/lib/cpp2/security/SecurityKillSwitch.h>
 #include <folly/Singleton.h>
 
+#include <gflags/gflags.h>
+
 DEFINE_string(
     thrift_security_tls_kill_switch_file,
     "/var/thrift_security/disable_thrift_security_tls",


### PR DESCRIPTION
I'm trying to compile Thrift on GCC 6.1.1 and ran into some bugs. Fixes are in this PR.