### PR TITLE
m4: revert ax_boost_python

### DIFF
--- a/thrift/m4/ax_boost_python.m4
+++ b/thrift/m4/ax_boost_python.m4
@@ -25,7 +25,7 @@
 # LICENSE
 #
 #   Copyright (c) 2008 Michael Tindal
-#   Copyright (c) 2013 Daniel M"ullner <daniel@danifold.net>
+#   Copyright (c) 2013 Daniel Mullner <muellner@math.stanford.edu>
 #
 #   This program is free software; you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the
@@ -53,69 +53,39 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 21
+#serial 18
 
 AC_DEFUN([AX_BOOST_PYTHON],
 [AC_REQUIRE([AX_PYTHON_DEVEL])dnl
-AC_REQUIRE([AX_BOOST_BASE])dnl
-AC_LANG_PUSH([C++])
-ax_boost_python_save_CPPFLAGS="$CPPFLAGS"
-ax_boost_python_save_LDFLAGS="$LDFLAGS"
-ax_boost_python_save_LIBS="$LIBS"
-if test "x$PYTHON_CPPFLAGS" != "x"; then
-  CPPFLAGS="$PYTHON_CPPFLAGS $CPPFLAGS"
-fi
-
-# Versions of AX_PYTHON_DEVEL() before serial 18 provided PYTHON_LDFLAGS
-# instead of PYTHON_LIBS, so this is just here for compatibility.
-if test "x$PYTHON_LDFLAGS" != "x"; then
-  LDFLAGS="$PYTHON_LDFLAGS $LDFLAGS"
-fi
-
-# Note: Only versions of AX_PYTHON_DEVEL() since serial 18 provide PYTHON_LIBS
-# instead of PYTHON_LDFLAGS.
-if test "x$PYTHON_LIBS" != "x"; then
-  LIBS="$PYTHON_LIBS $LIBS"
-fi
-
-if test "x$BOOST_CPPFLAGS" != "x"; then
-  CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
-fi
-if test "x$BOOST_LDFLAGS" != "x"; then
-  LDFLAGS="$BOOST_LDFLAGS $LDFLAGS"
-fi
 AC_CACHE_CHECK(whether the Boost::Python library is available,
 ac_cv_boost_python,
-[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <boost/python/module.hpp>
-BOOST_PYTHON_MODULE(test) { throw "Boost::Python test."; }]], [])],
-    ac_cv_boost_python=yes, ac_cv_boost_python=no)
+[AC_LANG_SAVE
+ AC_LANG_CPLUSPLUS
+ CPPFLAGS_SAVE="$CPPFLAGS"
+ if test x$PYTHON_CPPFLAGS != x; then
+   CPPFLAGS="$PYTHON_CPPFLAGS $CPPFLAGS"
+ fi
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+ #include <boost/python/module.hpp>
+ using namespace boost::python;
+ BOOST_PYTHON_MODULE(test) { throw "Boost::Python test."; }]],
+	[[return 0;]])],
+	ac_cv_boost_python=yes, ac_cv_boost_python=no)
+ AC_LANG_RESTORE
+ CPPFLAGS="$CPPFLAGS_SAVE"
 ])
 if test "$ac_cv_boost_python" = "yes"; then
   AC_DEFINE(HAVE_BOOST_PYTHON,,[define if the Boost::Python library is available])
   ax_python_lib=boost_python
   AC_ARG_WITH([boost-python],AS_HELP_STRING([--with-boost-python],[specify yes/no or the boost python library or suffix to use]),
-  [if test "x$with_boost_python" != "xno" -a "x$with_boost_python" != "xyes"; then
+  [if test "x$with_boost_python" != "xno"; then
      ax_python_lib=$with_boost_python
      ax_boost_python_lib=boost_python-$with_boost_python
    fi])
   BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
-  for ax_lib in $ax_python_lib $ax_boost_python_lib `ls $BOOSTLIBDIR/libboost_python*.so* $BOOSTLIBDIR/libboost_python*.dylib* $BOOSTLIBDIR/libboost_python*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_python.*\)\.so.*$;\1;' -e 's;^lib\(boost_python.*\)\.dylib.*$;\1;' -e 's;^lib\(boost_python.*\)\.a.*$;\1;' ` boost_python boost_python3; do
-    AS_VAR_PUSHDEF([ax_Lib], [ax_cv_lib_$ax_lib''_BOOST_PYTHON_MODULE])dnl
-    AC_CACHE_CHECK([whether $ax_lib is the correct library], [ax_Lib],
-    [LIBS="-l$ax_lib $ax_boost_python_save_LIBS $PYTHON_LIBS"
-    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-#include <boost/python/module.hpp>
-BOOST_PYTHON_MODULE(test) { throw "Boost::Python test."; }]], [])],
-        [AS_VAR_SET([ax_Lib], [yes])],
-        [AS_VAR_SET([ax_Lib], [no])])])
-    AS_VAR_IF([ax_Lib], [yes], [BOOST_PYTHON_LIB=$ax_lib break], [])
-    AS_VAR_POPDEF([ax_Lib])dnl
+  for ax_lib in `ls $BOOSTLIBDIR/libboost_python*.so* $BOOSTLIBDIR/libboost_python*.dylib* $BOOSTLIBDIR/libboost_python*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_python.*\)\.so.*$;\1;' -e 's;^lib\(boost_python.*\)\.dylib.*$;\1;' -e 's;^lib\(boost_python.*\)\.a.*$;\1;' ` $ax_python_lib $ax_boost_python_lib boost_python; do
+    AC_CHECK_LIB($ax_lib, exit, [BOOST_PYTHON_LIB=$ax_lib break], , [$PYTHON_LDFLAGS])
   done
   AC_SUBST(BOOST_PYTHON_LIB)
 fi
-CPPFLAGS="$ax_boost_python_save_CPPFLAGS"
-LDFLAGS="$ax_boost_python_save_LDFLAGS"
-LIBS="$ax_boost_python_save_LIBS"
-AC_LANG_POP([C++])
 ])dnl


### PR DESCRIPTION
I believe this is what caused the build errors after
e81111bafe36a2263830d2e2801cb7416f58f3b4 in the buildbot.