### PR TITLE
Fix Travis issues caused by zstd dependency

### DIFF
--- a/thrift/build/deps_common.sh
+++ b/thrift/build/deps_common.sh
@@ -19,6 +19,16 @@ install_mstch() {
   popd
 }
 
+install_zstd() {
+  pushd .
+  if [[ ! -e 'zstd' ]]; then
+    git clone https://github.com/facebook/zstd.git ./zstd
+  fi
+  cd zstd
+  sudo make install
+  popd
+}
+
 install_folly() {
   pushd .
   if [[ ! -e "folly" ]]; then

--- a/thrift/build/deps_ubuntu_12.04.sh
+++ b/thrift/build/deps_ubuntu_12.04.sh
@@ -18,6 +18,7 @@ sudo apt-get install git cmake
 install_folly ubuntu_12.04  # needs git
 install_mstch ubuntu_12.04  # needs git, cmake
 install_wangle ubuntu_12.04
+install_zstd ubuntu_12.04
 
 # Uses PPAs set up by folly.  TODO: According to the fbthrift docs,
 # pkg-config is missing.  However, things seem to build fine...

--- a/thrift/build/deps_ubuntu_14.04.sh
+++ b/thrift/build/deps_ubuntu_14.04.sh
@@ -2,6 +2,7 @@
 
 . "$(dirname "$0")/deps_common.sh"
 
+sudo apt-key update
 sudo apt-get install -y libdouble-conversion-dev libssl-dev make zip git \
   autoconf libtool g++ libboost-all-dev libevent-dev flex bison \
   libgoogle-glog-dev scons libkrb5-dev libsnappy-dev libsasl2-dev \
@@ -10,4 +11,5 @@ sudo apt-get install -y libdouble-conversion-dev libssl-dev make zip git \
 install_folly ubuntu_14.04  # needs git
 install_mstch ubuntu_14.04  # needs git, cmake
 install_wangle ubuntu_14.04 # needs git, cmake
+install_zstd ubuntu_14.04
 


### PR DESCRIPTION
Fix the travis build by installing `zstd` in the installation scripts, which has been required since https://github.com/facebook/fbthrift/commit/ec42813f0ced737617d4614900ef3a96c1f3d17f.

Also fixes an issue where apt-get would have outdated keys when installing dependencies.