### PR TITLE
fix legacy ->join() call

### DIFF
--- a/thrift/lib/hack/src/ThriftAsyncProcessor.php
+++ b/thrift/lib/hack/src/ThriftAsyncProcessor.php
@@ -48,6 +48,6 @@ abstract class ThriftAsyncProcessor extends ThriftProcessorBase
   }
 
   final public function process(TProtocol $input, TProtocol $output): bool {
-    return $this->processAsync($input, $output)->getWaitHandle()->join();
+    return HH\Asio\join($this->processAsync($input, $output)->getWaitHandle());
   }
 }


### PR DESCRIPTION
Fix fatal with HHVM 3.19 by updating legacy ->join() call to use HH\Asio\join()