### PR TITLE
Fix `make install` of various header files

### DIFF
--- a/thrift/lib/cpp/Makefile.am
+++ b/thrift/lib/cpp/Makefile.am
@@ -103,6 +103,7 @@ libthriftz_la_LDFLAGS   = -version-info $(LT_VERSION) $(BOOST_LDFLAGS)
 
 include_thriftdir = $(includedir)/thrift/lib/cpp/
 include_thrift_HEADERS = \
+                         DistinctTable.h \
                          EventHandlerBase.h \
                          Reflection.h \
                          TDispatchProcessor.h \

--- a/thrift/lib/cpp2/Makefile.am
+++ b/thrift/lib/cpp2/Makefile.am
@@ -99,7 +99,11 @@ thrift2include_frozen2_HEADERS = \
 	frozen/FrozenTrivial-inl.h \
 	frozen/HintTypes.h \
 	frozen/Traits.h \
-	frozen/VectorAssociative.h \
+	frozen/VectorAssociative.h
+
+thrift2include_frozen2_schemadir = $(thrift2include_frozen2dir)/schema
+
+thrift2include_frozen2_schema_HEADERS = \
 	frozen/schema/MemorySchema.h
 
 libthriftfrozen2_la_SOURCES = \


### PR DESCRIPTION
Summary:
`make install` was putting `lib/cpp2/frozen/schema/MemorySchema.h`
in `$include_dir/lib/cpp2/frozen/` and wasn't installing
`lib/cpp/DistinctTable.h` at all.

Thrift servers would therefore not compile due to missing headers.

Test Plan:
https://github.com/facebookincubator/beringei build succeeds with
this change applied and fails without it.