### PR TITLE
Updated README.md for readability and context

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,24 @@ Facebook Thrift [![Build Status](https://travis-ci.org/facebook/fbthrift.svg?bra
 
 Thrift is a serialization and RPC framework for service communication. Thrift enables these features in all major languages, and there is strong support for C++, Python, Hack, and Java. Most services at Facebook are written using Thrift for RPC, and some storage systems use Thrift for serializing records on disk.
 
-At a high level, Thrift is three major things:
+Facebook Thrift is not a distribution of [Apache Thrift](https://thrift.apache.org/). This is an evolved internal branch of Thrift that Facebook re-released to open source community in February 2014.  
+Although not all Apache Thrift changes are reflected in fbthrift, we track the upstream closely and hope to work with the maintainers to incorporate this work. Read more about what lead to this duality in the Facebook Code [blog post](https://code.facebook.com/posts/1468950976659943/under-the-hood-building-and-open-sourcing-fbthrift/)
 
 Table of Contents (ToC):
 =========================
-
-* [A Code Generator](#a-code-generator)
-* [A Serialization Framework](#a-serialization-framework)
-* [An RPC Framework](#an-rpc-framework)
+* The Three Things About Thrift
+  * [A Code Generator](#a-code-generator)
+  * [A Serialization Framework](#a-serialization-framework)
+  * [An RPC Framework](#an-rpc-framework)
 * [Building](#building)
-* [Dependencies](#dependencies)
-* [Build](#build)
-* [Thrift Files](#thrift-files)
+  * [Dependencies](#dependencies)
+  * [Build](#build)
+  * [Thrift Files](#thrift-files)
 * [C++ Static Reflection](#c-static-reflection)
 
+
+## About Thrift
+At a high level, Thrift is three major things:
 
 ### A Code Generator
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ Facebook Thrift [![Build Status](https://travis-ci.org/facebook/fbthrift.svg?bra
 
 Thrift is a serialization and RPC framework for service communication. Thrift enables these features in all major languages, and there is strong support for C++, Python, Hack, and Java. Most services at Facebook are written using Thrift for RPC, and some storage systems use Thrift for serializing records on disk.
 
-Facebook Thrift is not a distribution of [Apache Thrift](https://thrift.apache.org/). This is an evolved internal branch of Thrift that Facebook re-released to open source community in February 2014.  
-Although not all Apache Thrift changes are reflected in fbthrift, we track the upstream closely and hope to work with the maintainers to incorporate this work. Read more about what lead to this duality in the Facebook Code [blog post](https://code.facebook.com/posts/1468950976659943/under-the-hood-building-and-open-sourcing-fbthrift/)
+Facebook Thrift is not a distribution of [Apache Thrift](https://thrift.apache.org/). This is an evolved internal branch of Thrift that Facebook re-released to open source community in February 2014. Facebook Thrift was originally released closely tracking Apache Thrift but is now evolving in new directions. In particular, the compiler was rewritten from scratch and the new implementation features a fully asynchronous Thrift server. Read more about these improvements in the [ThriftServer documentation](https://github.com/facebook/fbthrift/blob/master/thrift/doc/Cpp2.md). 
+
+You can also learn more about this project in the original Facebook Code [blog post](https://code.facebook.com/posts/1468950976659943/under-the-hood-building-and-open-sourcing-fbthrift/)
 
 Table of Contents (ToC):
 =========================


### PR DESCRIPTION
Updated README.md to accomplish better readability without logical interruptions and provide background on the project.

- Table of Contents is moved above "Three things [..]" statement.
  Here is one reason: it's weird when you have a colon at the end
  of a sentence and then context completely changes. If you're about
  to describe 3 things, make sure they are right next to that sentence
- Table of Contents is re-formatted to reflect the heading structure
  of the README article. The ## headings are at the root of the list
  and the ### headings are on the second level.
- A short statement is added clarifying the fact of fbthrift's uniqueness,
  its roots, and relationship to the Apache Thrift project. This is done
  based on the text of the original FB Code release blog and links to it and
  the Apache Thrift distribution have been added accordingly.