### PR TITLE
Fix exception type support in cocoa generator

### DIFF
--- a/thrift/compiler/generate/t_cocoa_generator.cc
+++ b/thrift/compiler/generate/t_cocoa_generator.cc
@@ -358,6 +358,7 @@ string t_cocoa_generator::cocoa_thrift_imports() {
       "TObjective-C",
       "TBase",
       kStructInheritanceRootObjectName,
+      kExceptionInheritanceRootObjectName,
   };
 
   string result = "";
@@ -649,7 +650,7 @@ void t_cocoa_generator::generate_cocoa_struct_interface(ofstream &out,
   out << "@interface " << cocoa_prefix_ << tstruct->get_name() << " : ";
 
   if (is_exception) {
-    out << "NSException ";
+    out << kExceptionInheritanceRootObjectName;
   } else {
     out << kStructInheritanceRootObjectName;
   }

--- a/thrift/lib/cocoa/src/TBaseException.h
+++ b/thrift/lib/cocoa/src/TBaseException.h
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "TProtocol.h"
+
+@interface TBaseException : NSException <NSCopying, NSMutableCopying>
+
+/**
+ * convert this instance to immutable
+ *
+ * @return YES in case the object is immutable.
+ */
+- (BOOL) makeImmutable;
+
+/**
+ * check whether this instance is immutable
+ */
+- (BOOL) isImmutable;
+
+/**
+ * check whether this instance is mutable
+ */
+- (BOOL) isMutable;
+
+/**
+ * throw an exception in case this instance is immutable.
+ */
+- (void) throwExceptionIfImmutable;
+
+@end
+
+

--- a/thrift/lib/cocoa/src/TBaseException.m
+++ b/thrift/lib/cocoa/src/TBaseException.m
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "TBaseException.h"
+#import "TException.h"
+
+@implementation TBaseException {
+    BOOL _troot_is_immutable;
+}
+
+- (instancetype) init
+{
+    self = [super init];
+    if (self) {
+        _troot_is_immutable = NO;
+    }
+    return self;
+}
+
+- (BOOL) makeImmutable
+{
+    if (!_troot_is_immutable) {
+        _troot_is_immutable = YES;
+    }
+    return _troot_is_immutable;
+}
+
+- (BOOL) isImmutable
+{
+    return _troot_is_immutable;
+}
+
+- (BOOL) isMutable
+{
+    return !_troot_is_immutable;
+}
+
+- (void) throwExceptionIfImmutable
+{
+    if (_troot_is_immutable) {
+        @throw [TException exceptionWithName: @"TException"
+                                      reason:
+                [NSString stringWithFormat:@"can't mutate immutable: %@", [self description]]];
+    }
+}
+
+- (id) mutableCopyWithZone:(NSZone *)zone
+{
+    @throw [TException exceptionWithName: @"TException"
+                                  reason:
+            [NSString stringWithFormat:@"must implement mutableCopyWithZone for: %@", [self class]]];
+}
+
+- (id) copyWithZone:(NSZone *)zone
+{
+    id immutableCopy = [self mutableCopy];
+    [immutableCopy makeImmutable];
+    return immutableCopy;
+}
+
+@end


### PR DESCRIPTION
Currently it seems it's not possible to create an exception type via fbthrift. For example if you declare the following exception:

```
exception RetriableRPCException {
    1: i32 errorCode,
    2: string message,
}
```

The cocoa generator creates the same output as a struct except it inherits from `NSException` instead of `TBaseStruct`. The problem is that it is adding getter and setter that are calling immutable methods as well as the `makeImmutable` method that all are only implemented in TBaseStruct. My current thinking is that there would be 2 different ways to solve this. Both are implemented in this PR and one or the other can be removed easily if decided to move forward with one of these two.

1 Approach. Create protocol `TImmutable`
- Create a protocol that defines the immutability: TImmutable
- Implement <TImmutable> in TBaseStruct and TBaseException that inherits from NSException
- To create kind of a hack for multiple inherits we can create a macro that implements all the immutability methods we need for both classes

2 Approach. We remove immutability support for exception types

Please let me know what you think about which approach would be preferable or some other idea :)