### PR TITLE
Fix pass by reference at the callsite

### DIFF
--- a/thrift/lib/hack/import_from_www.php
+++ b/thrift/lib/hack/import_from_www.php
@@ -180,7 +180,7 @@ class ImportThriftLibFromWWW {
         }
 
         if (!$includes->isEmpty()) {
-          sort($includes);
+          sort(&$includes);
           $hacklib = 'require_once ($GLOBALS["HACKLIB_ROOT"]);';
           $thrift_root_path = '__DIR__';
 

--- a/thrift/lib/hack/src/TBase.php
+++ b/thrift/lib/hack/src/TBase.php
@@ -78,13 +78,13 @@ abstract class TBase {
             $xfer += $key->read($input);
             break;
           case TType::MAP:
-            $xfer += $this->_readMap($key, $kspec, $input);
+            $xfer += $this->_readMap(&$key, $kspec, $input);
             break;
           case TType::LST:
-            $xfer += $this->_readList($key, $kspec, $input, false);
+            $xfer += $this->_readList(&$key, $kspec, $input, false);
             break;
           case TType::SET:
-            $xfer += $this->_readList($key, $kspec, $input, true);
+            $xfer += $this->_readList(&$key, $kspec, $input, true);
             break;
         }
       }
@@ -98,13 +98,13 @@ abstract class TBase {
             $xfer += $val->read($input);
             break;
           case TType::MAP:
-            $xfer += $this->_readMap($val, $vspec, $input);
+            $xfer += $this->_readMap(&$val, $vspec, $input);
             break;
           case TType::LST:
-            $xfer += $this->_readList($val, $vspec, $input, false);
+            $xfer += $this->_readList(&$val, $vspec, $input, false);
             break;
           case TType::SET:
-            $xfer += $this->_readList($val, $vspec, $input, true);
+            $xfer += $this->_readList(&$val, $vspec, $input, true);
             break;
         }
       }
@@ -144,13 +144,13 @@ abstract class TBase {
             $xfer += $elem->read($input);
             break;
           case TType::MAP:
-            $xfer += $this->_readMap($elem, $espec, $input);
+            $xfer += $this->_readMap(&$elem, $espec, $input);
             break;
           case TType::LST:
-            $xfer += $this->_readList($elem, $espec, $input, false);
+            $xfer += $this->_readList(&$elem, $espec, $input, false);
             break;
           case TType::SET:
-            $xfer += $this->_readList($elem, $espec, $input, true);
+            $xfer += $this->_readList(&$elem, $espec, $input, true);
             break;
         }
       }
@@ -195,15 +195,15 @@ abstract class TBase {
                 $xfer += $this->$var->read($input);
                 break;
               case TType::MAP:
-                $xfer += $this->_readMap($this->$var, $fspec, $input);
+                $xfer += $this->_readMap(&$this->$var, $fspec, $input);
                 break;
               case TType::LST:
                 $xfer +=
-                  $this->_readList($this->$var, $fspec, $input, false);
+                  $this->_readList(&$this->$var, $fspec, $input, false);
                 break;
               case TType::SET:
                 $xfer +=
-                  $this->_readList($this->$var, $fspec, $input, true);
+                  $this->_readList(&$this->$var, $fspec, $input, true);
                 break;
             }
           }

--- a/thrift/lib/hack/src/TException.php
+++ b/thrift/lib/hack/src/TException.php
@@ -84,13 +84,13 @@ class TException extends Exception {
             $xfer += $key->read($input);
             break;
           case TType::MAP:
-            $xfer += $this->_readMap($key, $kspec, $input);
+            $xfer += $this->_readMap(&$key, $kspec, $input);
             break;
           case TType::LST:
-            $xfer += $this->_readList($key, $kspec, $input, false);
+            $xfer += $this->_readList(&$key, $kspec, $input, false);
             break;
           case TType::SET:
-            $xfer += $this->_readList($key, $kspec, $input, true);
+            $xfer += $this->_readList(&$key, $kspec, $input, true);
             break;
         }
       }
@@ -104,13 +104,13 @@ class TException extends Exception {
             $xfer += $val->read($input);
             break;
           case TType::MAP:
-            $xfer += $this->_readMap($val, $vspec, $input);
+            $xfer += $this->_readMap(&$val, $vspec, $input);
             break;
           case TType::LST:
-            $xfer += $this->_readList($val, $vspec, $input, false);
+            $xfer += $this->_readList(&$val, $vspec, $input, false);
             break;
           case TType::SET:
-            $xfer += $this->_readList($val, $vspec, $input, true);
+            $xfer += $this->_readList(&$val, $vspec, $input, true);
             break;
         }
       }
@@ -150,13 +150,13 @@ class TException extends Exception {
             $xfer += $elem->read($input);
             break;
           case TType::MAP:
-            $xfer += $this->_readMap($elem, $espec, $input);
+            $xfer += $this->_readMap(&$elem, $espec, $input);
             break;
           case TType::LST:
-            $xfer += $this->_readList($elem, $espec, $input, false);
+            $xfer += $this->_readList(&$elem, $espec, $input, false);
             break;
           case TType::SET:
-            $xfer += $this->_readList($elem, $espec, $input, true);
+            $xfer += $this->_readList(&$elem, $espec, $input, true);
             break;
         }
       }
@@ -201,15 +201,15 @@ class TException extends Exception {
                 $xfer += $this->$var->read($input);
                 break;
               case TType::MAP:
-                $xfer += $this->_readMap($this->$var, $fspec, $input);
+                $xfer += $this->_readMap(&$this->$var, $fspec, $input);
                 break;
               case TType::LST:
                 $xfer +=
-                  $this->_readList($this->$var, $fspec, $input, false);
+                  $this->_readList(&$this->$var, $fspec, $input, false);
                 break;
               case TType::SET:
                 $xfer +=
-                  $this->_readList($this->$var, $fspec, $input, true);
+                  $this->_readList(&$this->$var, $fspec, $input, true);
                 break;
             }
           }

--- a/thrift/lib/hack/src/ThriftAsyncProcessor.php
+++ b/thrift/lib/hack/src/ThriftAsyncProcessor.php
@@ -23,7 +23,7 @@ abstract class ThriftAsyncProcessor extends ThriftProcessorBase
     $fname = '';
     $mtype = 0;
 
-    $input->readMessageBegin($fname, $mtype, $rseqid);
+    $input->readMessageBegin(&$fname, &$mtype, &$rseqid);
     $methodname = 'process_'.$fname;
     if (!method_exists($this, $methodname)) {
       $handler_ctx = $this->eventHandler_->getHandlerContext($fname);

--- a/thrift/lib/hack/src/ThriftSyncProcessor.php
+++ b/thrift/lib/hack/src/ThriftSyncProcessor.php
@@ -20,7 +20,7 @@ abstract class ThriftSyncProcessor
     $fname = '';
     $mtype = 0;
 
-    $input->readMessageBegin($fname, $mtype, $rseqid);
+    $input->readMessageBegin(&$fname, &$mtype, &$rseqid);
     $methodname = 'process_'.$fname;
     if (!method_exists($this, $methodname)) {
       $handler_ctx = $this->eventHandler_->getHandlerContext($fname);

--- a/thrift/lib/hack/src/ThriftUnionSerializationTrait.php
+++ b/thrift/lib/hack/src/ThriftUnionSerializationTrait.php
@@ -10,7 +10,7 @@ trait ThriftUnionSerializationTrait implements \IThriftStruct {
       $protocol,
       $this,
       /* HH_IGNORE_ERROR[4053] every thrift union has a _type field */
-      $this->_type
+      &$this->_type
     );
   }
 

--- a/thrift/lib/hack/src/protocol/TProtocol.php
+++ b/thrift/lib/hack/src/protocol/TProtocol.php
@@ -209,26 +209,26 @@ abstract class TProtocol {
     $_ref = null;
     switch ($type) {
       case TType::BOOL:
-        return $this->readBool($_ref);
+        return $this->readBool(&$_ref);
       case TType::BYTE:
-        return $this->readByte($_ref);
+        return $this->readByte(&$_ref);
       case TType::I16:
-        return $this->readI16($_ref);
+        return $this->readI16(&$_ref);
       case TType::I32:
-        return $this->readI32($_ref);
+        return $this->readI32(&$_ref);
       case TType::I64:
-        return $this->readI64($_ref);
+        return $this->readI64(&$_ref);
       case TType::DOUBLE:
-        return $this->readDouble($_ref);
+        return $this->readDouble(&$_ref);
       case TType::FLOAT:
-        return $this->readFloat($_ref);
+        return $this->readFloat(&$_ref);
       case TType::STRING:
-        return $this->readString($_ref);
+        return $this->readString(&$_ref);
       case TType::STRUCT: {
-          $result = $this->readStructBegin($_ref);
+          $result = $this->readStructBegin(&$_ref);
           while (true) {
             $ftype = null;
-            $result += $this->readFieldBegin($_ref, $ftype, $_ref);
+            $result += $this->readFieldBegin(&$_ref, &$ftype, &$_ref);
             if ($ftype == TType::STOP) {
               break;
             }
@@ -242,7 +242,7 @@ abstract class TProtocol {
           $keyType = null;
           $valType = null;
           $size = 0;
-          $result = $this->readMapBegin($keyType, $valType, $size);
+          $result = $this->readMapBegin(&$keyType, &$valType, &$size);
           for ($i = 0; $size === null || $i < $size; $i++) {
             if ($size === null && !$this->readMapHasNext()) {
               break;
@@ -256,7 +256,7 @@ abstract class TProtocol {
       case TType::SET: {
           $elemType = null;
           $size = 0;
-          $result = $this->readSetBegin($elemType, $size);
+          $result = $this->readSetBegin(&$elemType, &$size);
           for ($i = 0; $size === null || $i < $size; $i++) {
             if ($size === null && !$this->readSetHasNext()) {
               break;
@@ -269,7 +269,7 @@ abstract class TProtocol {
       case TType::LST: {
           $elemType = null;
           $size = 0;
-          $result = $this->readListBegin($elemType, $size);
+          $result = $this->readListBegin(&$elemType, &$size);
           for ($i = 0; $size === null || $i < $size; $i++) {
             if ($size === null && !$this->readSetHasNext()) {
               break;

--- a/thrift/lib/hack/src/protocol/binary/TBinaryProtocolBase.php
+++ b/thrift/lib/hack/src/protocol/binary/TBinaryProtocolBase.php
@@ -305,7 +305,7 @@ abstract class TBinaryProtocolBase extends TProtocol {
 
   public function readMessageBegin(&$name, &$type, &$seqid) {
     $sz = 0;
-    $result = $this->readI32($sz);
+    $result = $this->readI32(&$sz);
     if ($sz < 0) {
       $version = $sz & self::VERSION_MASK;
       if ($version != self::VERSION_1) {
@@ -315,7 +315,7 @@ abstract class TBinaryProtocolBase extends TProtocol {
         );
       }
       $type = $sz & 0x000000ff;
-      $result += $this->readString($name) + $this->readI32($seqid);
+      $result += $this->readString(&$name) + $this->readI32(&$seqid);
     } else {
       if ($this->strictRead_) {
         throw new TProtocolException(
@@ -334,7 +334,7 @@ abstract class TBinaryProtocolBase extends TProtocol {
         }
         // Handle pre-versioned input
         $name = $this->trans_->readAll($sz);
-        $result += $sz + $this->readByte($type) + $this->readI32($seqid);
+        $result += $sz + $this->readByte(&$type) + $this->readI32(&$seqid);
       }
     }
     $this->sequenceID = $seqid;
@@ -356,12 +356,12 @@ abstract class TBinaryProtocolBase extends TProtocol {
   }
 
   public function readFieldBegin(&$name, &$fieldType, &$fieldId) {
-    $result = $this->readByte($fieldType);
+    $result = $this->readByte(&$fieldType);
     if ($fieldType == TType::STOP) {
       $fieldId = 0;
       return $result;
     }
-    $result += $this->readI16($fieldId);
+    $result += $this->readI16(&$fieldId);
     return $result;
   }
 
@@ -371,9 +371,9 @@ abstract class TBinaryProtocolBase extends TProtocol {
 
   public function readMapBegin(&$keyType, &$valType, &$size) {
     return
-      $this->readByte($keyType) +
-      $this->readByte($valType) +
-      $this->readI32($size);
+      $this->readByte(&$keyType) +
+      $this->readByte(&$valType) +
+      $this->readI32(&$size);
   }
 
   public function readMapEnd() {
@@ -381,7 +381,7 @@ abstract class TBinaryProtocolBase extends TProtocol {
   }
 
   public function readListBegin(&$elemType, &$size) {
-    return $this->readByte($elemType) + $this->readI32($size);
+    return $this->readByte(&$elemType) + $this->readI32(&$size);
   }
 
   public function readListEnd() {
@@ -389,7 +389,7 @@ abstract class TBinaryProtocolBase extends TProtocol {
   }
 
   public function readSetBegin(&$elemType, &$size) {
-    return $this->readByte($elemType) + $this->readI32($size);
+    return $this->readByte(&$elemType) + $this->readI32(&$size);
   }
 
   public function readSetEnd() {
@@ -515,7 +515,7 @@ abstract class TBinaryProtocolBase extends TProtocol {
 
   public function readString(&$value) {
     $len = 0;
-    $result = $this->readI32($len);
+    $result = $this->readI32(&$len);
     if ($len) {
       $value = $this->trans_->readAll($len);
     } else {

--- a/thrift/lib/hack/src/protocol/binary/TBinarySerializer.php
+++ b/thrift/lib/hack/src/protocol/binary/TBinarySerializer.php
@@ -40,9 +40,9 @@ class TBinarySerializer extends TProtocolSerializer {
 
       $unused_name = $unused_type = $unused_seqid = null;
       $protocol->readMessageBegin(
-        $unused_name,
-        $unused_type,
-        $unused_seqid,
+        &$unused_name,
+        &$unused_type,
+        &$unused_seqid,
       );
     } else {
       $object->write($protocol);

--- a/thrift/lib/hack/src/protocol/compact/TCompactSerializer.php
+++ b/thrift/lib/hack/src/protocol/compact/TCompactSerializer.php
@@ -52,9 +52,9 @@ class TCompactSerializer extends TProtocolSerializer {
       }
       $unused_name = $unused_type = $unused_seqid = null;
       $protocol->readMessageBegin(
-        $unused_name,
-        $unused_type,
-        $unused_seqid,
+        &$unused_name,
+        &$unused_type,
+        &$unused_seqid,
       );
     } else {
       $object->write($protocol);

--- a/thrift/lib/hack/src/transport/THeaderTransport.php
+++ b/thrift/lib/hack/src/transport/THeaderTransport.php
@@ -303,7 +303,7 @@ class THeaderTransport extends TFramedTransport
     int &$index,
     int $limit,
   ): string {
-    $str_sz = $this->readVarint($data, $index);
+    $str_sz = $this->readVarint($data, &$index);
     if ($str_sz + $index > $limit) {
       throw new TTransportException(
         'String read too long',
@@ -333,8 +333,8 @@ class THeaderTransport extends TFramedTransport
     }
     $end_of_header = $index + $header_size;
 
-    $this->protoId_ = $this->readVarint($data, $index);
-    $numHeaders = $this->readVarint($data, $index);
+    $this->protoId_ = $this->readVarint($data, &$index);
+    $numHeaders = $this->readVarint($data, &$index);
     if ($this->protoId_ === 1 &&
         $this->clientType_ !== self::HTTP_CLIENT_TYPE) {
       throw new TTransportException(
@@ -345,7 +345,7 @@ class THeaderTransport extends TFramedTransport
 
     // Read in the headers.  Data for each header varies.
     for ($i = 0; $i < $numHeaders; $i++) {
-      $transId = $this->readVarint($data, $index);
+      $transId = $this->readVarint($data, &$index);
       switch ($transId) {
         case self::ZLIB_TRANSFORM:
         case self::SNAPPY_TRANSFORM:
@@ -372,13 +372,13 @@ class THeaderTransport extends TFramedTransport
     // Read the info headers
     $this->readHeaders = Map {};
     while ($index < $end_of_header) {
-      $infoId = $this->readVarint($data, $index);
+      $infoId = $this->readVarint($data, &$index);
       switch ($infoId) {
         case self::INFO_KEYVALUE:
-          $num_keys = $this->readVarint($data, $index);
+          $num_keys = $this->readVarint($data, &$index);
           for ($i = 0; $i < $num_keys; $i++) {
-            $strKey = $this->readString($data, $index, $end_of_header);
-            $strValue = $this->readString($data, $index, $end_of_header);
+            $strKey = $this->readString($data, &$index, $end_of_header);
+            $strValue = $this->readString($data, &$index, $end_of_header);
             $this->readHeaders[$strKey] = $strValue;
           }
           break;

--- a/thrift/lib/hack/src/transport/THttpClientPool.php
+++ b/thrift/lib/hack/src/transport/THttpClientPool.php
@@ -99,7 +99,7 @@ class THttpClientPool extends THttpClient {
    */
   public function flush(): void {
     if ($this->randomize_) {
-      shuffle($this->servers_);
+      shuffle(&$this->servers_);
     }
 
     foreach ($this->servers_ as $server) {

--- a/thrift/lib/hack/src/transport/TServerSocket.php
+++ b/thrift/lib/hack/src/transport/TServerSocket.php
@@ -38,8 +38,8 @@ class TServerSocket {
       $errstr = '';
       $this->handle = stream_socket_server(
         'tcp://'.$addr.':'.$this->port,
-        $errno,
-        $errstr,
+        &$errno,
+        &$errstr,
         STREAM_SERVER_BIND | STREAM_SERVER_LISTEN,
       );
       if ($this->handle !== false) {

--- a/thrift/lib/hack/src/transport/TSocket.php
+++ b/thrift/lib/hack/src/transport/TSocket.php
@@ -289,16 +289,16 @@ class TSocket extends TTransport
       $handle = @pfsockopen(
         $this->host_,
         $this->port_,
-        $this->errno_,
-        $this->errstr_,
+        &$this->errno_,
+        &$this->errstr_,
         $this->sendTimeout_ / 1000.0,
       );
     } else {
       $handle = @fsockopen(
         $this->host_,
         $this->port_,
-        $this->errno_,
-        $this->errstr_,
+        &$this->errno_,
+        &$this->errstr_,
         $this->sendTimeout_ / 1000.0,
       );
     }
@@ -323,7 +323,7 @@ class TSocket extends TTransport
     // IPv6 is returned [2401:db00:20:702c:face:0:7:0]:port
     // or when stream_socket_get_name is buggy it is
     // 2401:db00:20:702c:face:0:7:0:port
-    $this->lport_ = end(explode(":", $sock_name));
+    $this->lport_ = end(&explode(":", $sock_name));
 
     stream_set_timeout($this->handle_, 0, $this->sendTimeout_ * 1000);
     $this->sendTimeoutSet_ = true;
@@ -394,7 +394,7 @@ class TSocket extends TTransport
     }
 
     $excpt = array();
-    $ret = stream_select($read, $write, $excpt, 0, 0);
+    $ret = stream_select(&$read, &$write, &$excpt, 0, 0);
     if ($ret === false) {
       $error = 'TSocket: stream_select failed on socket.';
       if ($this->debug_) {


### PR DESCRIPTION
Update all pass by reference calls to be valid HHVM >=3.24 code. Generated by running:

  hhast-migrate --ctpbr thrift/lib/hack/