### PR TITLE
Fix type error in THttpClient

### DIFF
--- a/thrift/lib/hack/src/transport/THttpClient.php
+++ b/thrift/lib/hack/src/transport/THttpClient.php
@@ -57,7 +57,7 @@ class THttpClient extends TTransport implements IThriftRemoteConn {
    *
    * @var resource
    */
-  protected string $data_;
+  protected mixed $data_;
 
   /**
    * Error message
@@ -270,7 +270,7 @@ class THttpClient extends TTransport implements IThriftRemoteConn {
         TTransportException::UNKNOWN,
       );
     }
-    return $data;
+    return (string) $data;
   }
 
   /**


### PR DESCRIPTION
The data_ member in THttpClient is set from curl_exec which returns a mixed value, but data_ is typed as string. This changes data_ to mixed to match the return type and logic.