### PR TITLE
Renaming the iobuf Testing Service

### DIFF
--- a/thrift/lib/py3/test/CMakeLists.txt
+++ b/thrift/lib/py3/test/CMakeLists.txt
@@ -2,7 +2,7 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}/..")
 
 thrift_library(
     "iobuf"
-    "TestingService"
+    "IobufTestService"
     "cpp2"
     ""
     "${CMAKE_CURRENT_SOURCE_DIR}"
@@ -12,7 +12,7 @@ thrift_library(
 
 thrift_generate(
     "iobuf"
-    "TestingService"
+    "IobufTestService"
     "py3"
     ""
     "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/thrift/lib/py3/test/iobuf.thrift
+++ b/thrift/lib/py3/test/iobuf.thrift
@@ -9,7 +9,7 @@ struct Moo {
   3: IOBuf buf
 }
 
-service TestingService {
+service IobufTestService {
     Moo getMoo()
     void sendMoo(1: Moo m)
 }


### PR DESCRIPTION
Avoid conflict with testing.thrift, which also declares TestingService.
Without this, compliation that includes both test/iobuf and
test/testing; will fail.

Test Plan:

Build with thriftpy3=True and run the iobuf py3 unittest:
```
(cd ~/fbthrift/_build/thrift/lib/py3/test/gen-py3 && python3 -m unittest -v test.iobuf)
```