### PR TITLE
Build intermediate targets in binary directory

### DIFF
--- a/thrift/compiler/CMakeLists.txt
+++ b/thrift/compiler/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Set the compiler directory
-set(COMPILER_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(COMPILER_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
 # Override default install path for `make install` step
 set(CMAKE_INSTALL_PREFIX ${THRIFT_HOME})

--- a/thrift/lib/cpp2/transport/rsocket/CMakeLists.txt
+++ b/thrift/lib/cpp2/transport/rsocket/CMakeLists.txt
@@ -1,13 +1,11 @@
-# Set the lib directory
-set(LIB_THRIFT_HOME ${CMAKE_CURRENT_SOURCE_DIR})
 
 thrift_generate(
   "Config" #file_name
   "" #services
   "cpp2" #language
   "" #options
-  "${LIB_THRIFT_HOME}" #file_path
-  "${LIB_THRIFT_HOME}" #output_path
+  "${CMAKE_CURRENT_SOURCE_DIR}" #file_path
+  "${CMAKE_CURRENT_BINARY_DIR}" #output_path
   "thrift/lib/cpp2/transport/rsocket" #include_prefix
 )
 

--- a/thrift/lib/thrift/CMakeLists.txt
+++ b/thrift/lib/thrift/CMakeLists.txt
@@ -1,13 +1,10 @@
-# Set the lib directory
-set(LIB_THRIFT_HOME ${CMAKE_CURRENT_SOURCE_DIR})
-
 thrift_generate(
   "reflection" #file_name
   "" #services
   "cpp2" #language
   "templates" #options
-  "${LIB_THRIFT_HOME}" #file_path
-  "${LIB_THRIFT_HOME}" #output_path
+  "${CMAKE_CURRENT_SOURCE_DIR}" #file_path
+  "${CMAKE_CURRENT_BINARY_DIR}" #output_path
   "thrift/lib/thrift" #include_prefix
 )
 
@@ -16,8 +13,8 @@ thrift_generate(
   "" #services
   "cpp2" #language
   "" #options
-  "${LIB_THRIFT_HOME}" #file_path
-  "${LIB_THRIFT_HOME}" #output_path
+  "${CMAKE_CURRENT_SOURCE_DIR}" #file_path
+  "${CMAKE_CURRENT_BINARY_DIR}" #output_path
   "thrift/lib/thrift" #include_prefix
 )
 
@@ -26,8 +23,8 @@ thrift_generate(
   "" #services
   "cpp2" #language
   "" #options
-  "${LIB_THRIFT_HOME}" #file_path
-  "${LIB_THRIFT_HOME}" #output_path
+  "${CMAKE_CURRENT_SOURCE_DIR}" #file_path
+  "${CMAKE_CURRENT_BINARY_DIR}" #output_path
   "thrift/lib/thrift" #include_prefix
 )
 


### PR DESCRIPTION
Removes the duplicate use of LIB_THRIFT_HOME for different purposes,
which I feel risks confusion further down the line. I would like to encourage the file_path = `${CMAKE_CURRENT_SOURCE_DIR}` and output_path = `${CMAKE_CURRENT_BINARY_DIR}` as the default pattern as we move forward, because it fits with a clear pattern.

Test Plan:

On Ubuntu Bionic server:
```
$ mkdir fbthrift/_build
$ cd fbthrift/_build
$ cmake ..
$ make
$ git clean -xdn ..
```

Before the change the following files are listed in the source directory
after the change only the `_build` path is listed.