### PR TITLE
Generate Config and RpcMetadata sources generated before thriftcpp2

### DIFF
--- a/thrift/lib/cpp2/CMakeLists.txt
+++ b/thrift/lib/cpp2/CMakeLists.txt
@@ -96,6 +96,7 @@ add_library(
   ${RpcMetadata-cpp2-SOURCES}
   ${rsocket-cpp2-SOURCES}
 )
+add_dependencies(thriftcpp2 Config-cpp2-target RpcMetadata-cpp2-target)
 target_link_libraries(
   thriftcpp2
   PUBLIC


### PR DESCRIPTION
Without explicit rules it is possible to get build failures.

Fixes: #310 

Test Plan:

On Ubuntu 16.04:
```
$ mkdir fbthrift/_build
$ cd fbtrhift/_build
$ git clean -xdf    # Ensure no sources from previous build
$ rm -rf *
$ cmake ..
$ make -j 36 thriftcpp2 
```

Without my diffs the build fails, with them it succeeds.