### PR TITLE
Enforce minimum Bison version in CMake 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ option(thriftpy3
 
 # Find required dependencies for thrift/compiler
 if(compiler_only OR build_all)
-  find_package(BISON REQUIRED)
+  find_package(BISON 3.0.4 REQUIRED)
   find_package(FLEX REQUIRED)
   find_package(Mstch REQUIRED)
   include_directories(

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Please install the following dependencies before building Facebook Thrift:
 
 **System**:
 [Flex](https://www.gnu.org/software/flex),
-[Bison](https://www.gnu.org/software/bison),
+[Bison 3.1 or later](https://www.gnu.org/software/bison),
 [Boost](https://www.boost.org),
 [OpenSSLv1.0.2g](https://www.openssl.org),
 [PThreads](https://computing.llnl.gov/tutorials/pthreads),


### PR DESCRIPTION
Summary:
- The top-level `CMakeLists.txt` does not specify a minimum Bison version. This
  can lead to users with older Bison versions getting past the configure step
  but then fail to compile due to lack of grammar support such as:

```
parse/thrifty.yy:108.1-5: invalid directive: `%code'
parse/thrifty.yy:108.7-14: syntax error, unexpected identifier
```

- Update CMake to enforce a minimum version of `3.0.4` for Bison.
  This is not the desired or recommended minimum version as it has some
  undefined behavior which may cause issues with UBSAN.
- We cannot easily enforce Bison 3.1 for a variety of reasons. First, on
  Ubuntu 16.04, the latest `Bison` available via `apt` is `3.0.4` or one
  can install `bison++` which maps to version `3.1`. Note that `bison++`
  has a different versioning scheme and also uninstalls the original
  `bison` on the system. While one can wrap detection of `bison++` and
  an associated version or `Bison` and version `3.1`, `bison++` 1.23 at
  least does not support passing a file to `--defines`, which thrift
  compiler currently is relying on.
- Document the suggested version of Bison to use is 3.1 or later.