### PR TITLE
Ignore register deprecation warnings from flex-generated files

### DIFF
--- a/thrift/compiler/CMakeLists.txt
+++ b/thrift/compiler/CMakeLists.txt
@@ -42,6 +42,10 @@ target_compile_definitions(
  compiler_base
  PRIVATE -DTHRIFTY_HH="${COMPILER_DIR}/thrifty.hh"
 )
+target_compile_options(
+ compiler_base
+ PUBLIC "-Wno-deprecated-register"
+)
 target_link_libraries(
   compiler_base
 


### PR DESCRIPTION
Summary:
- Depending on the Flex version used, the generated code using Flex may
  emit code using the `register` keyword which is deprecated and then
  removed in C++17.
- Simply ignore this specific warning when building the `compiler_base`
  target.