### PR TITLE
Fix warnings about potentially evaluated expressions

### DIFF
--- a/thrift/lib/cpp2/async/RequestChannel.cpp
+++ b/thrift/lib/cpp2/async/RequestChannel.cpp
@@ -58,7 +58,7 @@ uint32_t RequestChannel::sendRequestSync(
     std::unique_ptr<apache::thrift::ContextStack> ctx,
     std::unique_ptr<folly::IOBuf> buf,
     std::shared_ptr<apache::thrift::transport::THeader> header) {
-  DCHECK(typeid(ClientSyncCallback) == typeid(*cb));
+  DCHECK(dynamic_cast<ClientSyncCallback*>(cb.get()));
   apache::thrift::RpcKind kind =
       static_cast<ClientSyncCallback&>(*cb).rpcKind();
   auto eb = getEventBase();

--- a/thrift/lib/cpp2/transport/core/ThriftClient.cpp
+++ b/thrift/lib/cpp2/transport/core/ThriftClient.cpp
@@ -120,7 +120,7 @@ uint32_t ThriftClient::sendRequestSync(
   EventBase* connectionEvb = connection_->getEventBase();
   DCHECK(!connectionEvb->inRunningEventBaseThread());
   folly::Baton<> baton;
-  DCHECK(typeid(ClientSyncCallback) == typeid(*cb));
+  DCHECK(dynamic_cast<ClientSyncCallback*>(cb.get()));
   auto kind = static_cast<ClientSyncCallback&>(*cb).rpcKind();
   bool oneway = kind == RpcKind::SINGLE_REQUEST_NO_RESPONSE;
   auto scb =


### PR DESCRIPTION
Summary:
- In a debug check, typeid may have side effects in dereferencing the
  callback pointer. This results in a warning with Clang:

```
[118/152] Building CXX object thrift/lib/cpp2/CMakeFiles/thriftcpp2.dir/async/RequestChannel.cpp.o
../thrift/lib/cpp2/async/RequestChannel.cpp:61:47: warning: expression with side effects will be evaluated despite being used as an operand to 'typeid' [-Wpotentially-evaluated-expression]
  DCHECK(typeid(ClientSyncCallback) == typeid(*cb));
                                              ^
1 warning generated.
[125/152] Building CXX object thrift/lib/cpp2/CMakeFiles/thriftcpp2.dir/transport/core/ThriftClient.cpp.o
../thrift/lib/cpp2/transport/core/ThriftClient.cpp:123:47: warning: expression with side effects will be evaluated despite being used as an operand to 'typeid' [-Wpotentially-evaluated-expression]
  DCHECK(typeid(ClientSyncCallback) == typeid(*cb));
                                              ^
1 warning generated.
```

- To avoid the warning, we can simply dynamic cast and see if the cast
  succeeds.