### PR TITLE
Replace boost::noncopyable with deleted copy constructors

### DIFF
--- a/thrift/lib/cpp/RelativePtr.h
+++ b/thrift/lib/cpp/RelativePtr.h
@@ -16,7 +16,6 @@
 #ifndef THRIFT_RELATIVEPTR_H_
 #define THRIFT_RELATIVEPTR_H_
 
-#include <boost/noncopyable.hpp>
 #include <glog/logging.h>
 
 namespace apache { namespace thrift {
@@ -27,12 +26,15 @@ typedef uint8_t byte;
 // TODO: expose 'OffsetType' as a type parameter in freeze()
 template<class T,
          class OffsetType = uint32_t>
-class RelativePtr : private boost::noncopyable {
+class RelativePtr {
   OffsetType offset_;
  public:
   RelativePtr() {
     reset(nullptr);
   }
+
+  RelativePtr(const RelativePtr&) = delete;
+  RelativePtr& operator=(const RelativePtr&) = delete;
 
   explicit RelativePtr(T* ptr) {
     reset(ptr);

--- a/thrift/lib/cpp/concurrency/Monitor.h
+++ b/thrift/lib/cpp/concurrency/Monitor.h
@@ -23,8 +23,6 @@
 #include <thrift/lib/cpp/concurrency/Exception.h>
 #include <thrift/lib/cpp/concurrency/Mutex.h>
 
-#include <boost/noncopyable.hpp>
-
 namespace apache { namespace thrift { namespace concurrency {
 
 /**
@@ -45,7 +43,7 @@ namespace apache { namespace thrift { namespace concurrency {
  *
  * @version $Id:$
  */
-class Monitor : boost::noncopyable {
+class Monitor {
  public:
   /** Creates a new mutex, and takes ownership of it. */
   Monitor();
@@ -55,6 +53,9 @@ class Monitor : boost::noncopyable {
 
   /** Uses the mutex inside the provided Monitor without taking ownership. */
   explicit Monitor(Monitor* monitor);
+
+  Monitor(const Monitor&) = delete;
+  Monitor& operator=(const Monitor&) = delete;
 
   /** Deallocates the mutex only if we own it. */
   virtual ~Monitor();

--- a/thrift/lib/cpp/concurrency/Mutex.h
+++ b/thrift/lib/cpp/concurrency/Mutex.h
@@ -19,7 +19,6 @@
 #include <cstdint>
 #include <chrono>
 #include <memory>
-#include <boost/noncopyable.hpp>
 
 namespace apache { namespace thrift { namespace concurrency {
 class PthreadMutex;
@@ -119,7 +118,7 @@ private:
   mutable volatile bool writerWaiting_;
 };
 
-class Guard : boost::noncopyable {
+class Guard {
  public:
   explicit Guard(const Mutex& value,
     std::chrono::milliseconds timeout = std::chrono::milliseconds::zero())
@@ -139,6 +138,9 @@ class Guard : boost::noncopyable {
   ~Guard() {
     release();
   }
+
+  Guard(const Guard&) = delete;
+  Guard& operator=(const Guard&) = delete;
 
   // Move constructor/assignment.
   Guard(Guard&& other) noexcept {
@@ -178,7 +180,7 @@ enum RWGuardType {
 };
 
 
-class RWGuard : boost::noncopyable {
+class RWGuard {
  public:
   explicit RWGuard(const ReadWriteMutex& value, bool write = false,
                    std::chrono::milliseconds timeout =
@@ -206,6 +208,9 @@ class RWGuard : boost::noncopyable {
           std::chrono::milliseconds timeout = std::chrono::milliseconds::zero())
       : RWGuard(value, type == RW_WRITE, timeout) {
   }
+
+  RWGuard(const RWGuard&) = delete;
+  RWGuard& operator=(const RWGuard&) = delete;
 
   ~RWGuard() {
     release();

--- a/thrift/lib/cpp/test/loadgen/Controller.h
+++ b/thrift/lib/cpp/test/loadgen/Controller.h
@@ -19,8 +19,6 @@
 #ifndef THRIFT_TEST_LOADGEN_CONTROLLER_H_
 #define THRIFT_TEST_LOADGEN_CONTROLLER_H_ 1
 
-#include <boost/noncopyable.hpp>
-
 #include <thrift/lib/cpp/concurrency/Monitor.h>
 #include <thrift/lib/cpp/test/loadgen/LoadConfig.h>
 #include <thrift/lib/cpp/test/loadgen/IntervalTimer.h>
@@ -39,11 +37,14 @@ class WorkerFactory;
 class WorkerIf;
 class Monitor;
 
-class Controller : private boost::noncopyable {
+class Controller {
  public:
   Controller(WorkerFactory* factory, Monitor* monitor,
       std::shared_ptr<LoadConfig> config,
       apache::thrift::concurrency::PosixThreadFactory* threadFactory = nullptr);
+
+  Controller(const Controller&) = delete;
+  Controller& operator=(const Controller&) = delete;
 
   void run(uint32_t numThreads, uint32_t maxThreads,
       double monitorInterval = 1.0);

--- a/thrift/lib/cpp/test/loadgen/Worker.h
+++ b/thrift/lib/cpp/test/loadgen/Worker.h
@@ -27,7 +27,6 @@
 #include <thrift/lib/cpp/concurrency/Util.h>
 #include <thrift/lib/cpp/TLogging.h>
 
-#include <boost/noncopyable.hpp>
 #include <memory>
 
 namespace apache { namespace thrift { namespace loadgen {
@@ -46,7 +45,7 @@ namespace apache { namespace thrift { namespace loadgen {
  * from LoadConfig.
  */
 template <typename ClientT, typename ConfigT = LoadConfig>
-class Worker : public WorkerIf, public boost::noncopyable {
+class Worker : public WorkerIf {
  public:
   typedef ClientT ClientType;
   typedef ConfigT ConfigType;
@@ -64,6 +63,9 @@ class Worker : public WorkerIf, public boost::noncopyable {
     , intervalTimer_(nullptr)
     , config_()
     , scoreboard_() {}
+
+  Worker(const Worker&) = delete;
+  Worker& operator=(const Worker&) = delete;
 
   /**
    * Initialize the Worker.

--- a/thrift/lib/cpp2/util/ScopedServerThread.h
+++ b/thrift/lib/cpp2/util/ScopedServerThread.h
@@ -21,7 +21,6 @@
 #ifndef THRIFT_UTIL_SCOPEDSERVERTHREAD_H_
 #define THRIFT_UTIL_SCOPEDSERVERTHREAD_H_ 1
 
-#include <boost/noncopyable.hpp>
 #include <memory>
 #include <string>
 
@@ -44,7 +43,7 @@ namespace util {
  * The server is stopped automatically when the ScopedServerThread is
  * destroyed.
  */
-class ScopedServerThread : public boost::noncopyable {
+class ScopedServerThread {
  public:
   /**
    * Create a new, unstarted ScopedServerThread object.
@@ -55,6 +54,9 @@ class ScopedServerThread : public boost::noncopyable {
    * Create a ScopedServerThread object and automatically start it.
    */
   explicit ScopedServerThread(std::shared_ptr<BaseThriftServer> server);
+
+  ScopedServerThread(const ScopedServerThread&) = delete;
+  ScopedServerThread& operator=(const ScopedServerThread&) = delete;
 
   virtual ~ScopedServerThread();
 


### PR DESCRIPTION
Summary:
- Replace usages of `boost::noncopyable` with deleted copy constructors
  and deleted copy assignment.
- Keep python compiler usages of `boost::noncopyable` in tact.