### PR TITLE
Use folly::to_underlying_type

### DIFF
--- a/thrift/lib/cpp/protocol/TDebugProtocol.h
+++ b/thrift/lib/cpp/protocol/TDebugProtocol.h
@@ -25,6 +25,8 @@
 #include <memory>
 #include <type_traits>
 
+#include <folly/Utility.h>
+
 namespace apache { namespace thrift { namespace protocol {
 
 /*
@@ -255,10 +257,7 @@ public:
   template<typename T>
   typename std::enable_if<std::is_enum<T>::value, void>::type
   write(const T value) {
-    // TODO: change the following to underlying_type when everyone
-    // upgraded to gcc-4.7
-    // write(static_cast<typename std::underlying_type<T>::type>(value));
-    write(static_cast<int64_t>(value));
+    write(folly::to_underlying_type(value));
   }
 
 

--- a/thrift/lib/cpp2/reflection/serializer.h
+++ b/thrift/lib/cpp2/reflection/serializer.h
@@ -25,6 +25,7 @@
 #include <fatal/type/call_traits.h>
 #include <fatal/type/trie.h>
 #include <folly/Traits.h>
+#include <folly/Utility.h>
 #include <thrift/lib/cpp2/GeneratedSerializationCodeHelper.h>
 #include <thrift/lib/cpp2/reflection/container_traits.h>
 #include <thrift/lib/cpp2/reflection/reflection.h>
@@ -811,8 +812,7 @@ struct protocol_methods<type_class::structure, Struct> {
 
       if (ftype == protocol_method::ttype_value) {
         detail::mark_isset<
-            static_cast<std::underlying_type<optionality>::type>(
-                member::optional::value),
+            folly::to_underlying_type(member::optional::value),
             required_fields,
             member>(required_isset, obj);
         protocol_method::read(

--- a/thrift/lib/cpp2/transport/rocket/framing/Frames.cpp
+++ b/thrift/lib/cpp2/transport/rocket/framing/Frames.cpp
@@ -26,6 +26,7 @@
 #include <folly/Format.h>
 #include <folly/Likely.h>
 #include <folly/Range.h>
+#include <folly/Utility.h>
 #include <folly/io/Cursor.h>
 #include <folly/io/IOBuf.h>
 
@@ -387,9 +388,8 @@ void ErrorFrame::serialize(Serializer& writer) && {
   nwritten += writer.write(streamId());
   nwritten += writer.writeFrameTypeAndFlags(frameType(), Flags::none());
 
-  using ErrorCodeInt = std::underlying_type_t<ErrorCode>;
   nwritten +=
-      writer.writeBE<ErrorCodeInt>(static_cast<ErrorCodeInt>(errorCode()));
+      writer.writeBE<ErrorCodeInt>(folly::to_underlying_type(errorCode()));
 
   nwritten += writer.writePayload(std::move(payload()));
 


### PR DESCRIPTION
Summary:
- Some call sites are verbose when casting an enum to its underlying
  type.
- Use the new utility in Folly: `to_underlying_type` to make the call
  sites more concise.