### PR TITLE
Make sure thrift_shared handles systems without rsocket

### DIFF
--- a/thrift/lib/cpp2/CMakeLists.txt
+++ b/thrift/lib/cpp2/CMakeLists.txt
@@ -157,9 +157,16 @@ if(thriftpy3)
       Folly::folly_pic
       sodium
       ${LIBGFLAGS_LIBRARY}
-      yarpl::yarpl
-      rsocket::ReactiveSocket
   )
+
+  if(TARGET rsocket::ReactiveSocket)
+    target_link_libraries(
+      thriftcpp2_shared
+      PUBLIC
+        yarpl::yarpl
+        rsocket::ReactiveSocket
+    )
+  endif()
 
   install(
     TARGETS


### PR DESCRIPTION
If build configured on system without rsocket, but thriftpy3 enabled the
build will fail.

Test Plan:

On Ubuntu 18.04 with and without rsocket install build with
cmake -Dthriftpy3=ON. In each case ensure the thrift-py3 unit tests run
with only the single expected failure:

```
  $ mkdir -p fbthrift/_build
  $ cd fbthrift/_build
  $ export PYTHONPATH=$(pwd)/thrift/lib/py3/cybld/
  $ cmake -Dthriftpy3=ON ..
  $ make
  $ cd thrift/lib/py3/test/gen-py3
  $ nosetests3 test/*.py
```