### PR TITLE
Replace folly::is_trivially_copyable with std::is_trivially_copyable

### DIFF
--- a/thrift/lib/cpp2/frozen/Frozen.h
+++ b/thrift/lib/cpp2/frozen/Frozen.h
@@ -824,7 +824,7 @@ enum class Frozen2 { Marker };
 template <
     class T,
     class =
-        typename std::enable_if<!folly::is_trivially_copyable<T>::value>::type,
+        typename std::enable_if<!std::is_trivially_copyable<T>::value>::type,
     class Return = Bundled<typename Layout<T>::View>>
 Return freeze(const T& x, Frozen2 = Frozen2::Marker) {
   std::unique_ptr<Layout<T>> layout(new Layout<T>);

--- a/thrift/lib/cpp2/frozen/FrozenTrivial-inl.h
+++ b/thrift/lib/cpp2/frozen/FrozenTrivial-inl.h
@@ -76,7 +76,7 @@ template <class T>
 struct IsBlitType
     : std::integral_constant<
           bool,
-          (folly::is_trivially_copyable<T>::value &&
+          (std::is_trivially_copyable<T>::value &&
            !std::is_pointer<T>::value && !std::is_enum<T>::value &&
            !std::is_integral<T>::value)> {};
 


### PR DESCRIPTION
Summary:
- Thrift requires a minimum compiler support where the compilers have
  all implemented `std::is_trivially_copyable`. So, replace the uses of
  `folly::is_trivially_copyable` with `std::is_trivially_copyable`.
- https://github.com/facebook/folly/pull/995 is a PR where
  `folly::is_trivially_copyable` may be going away shortly, so we should
  prepare for that.