### PR TITLE
Replace integral_constant<bool> with folly::bool_constant

### DIFF
--- a/thrift/lib/cpp2/GeneratedCodeHelper.h
+++ b/thrift/lib/cpp2/GeneratedCodeHelper.h
@@ -74,15 +74,14 @@ class container_traits {
   static std::true_type has_push_back(T*);
 
   template <typename T>
-  using is_map = std::integral_constant<bool, is_map_not_set<T>::value>;
+  using is_map = folly::bool_constant<is_map_not_set<T>::value>;
 
   template <typename T>
-  using is_set = std::integral_constant<bool,
-        is_map_or_set<T>::value && !is_map_not_set<T>::value>;
+  using is_set = folly::bool_constant<is_map_or_set<T>::value &&
+                                      !is_map_not_set<T>::value>;
 
   template <typename T>
-  using is_vector = std::integral_constant<bool,
-        !is_map_or_set<T>::value &&
+  using is_vector = folly::bool_constant<!is_map_or_set<T>::value &&
         decltype(has_push_back(static_cast<T*>(nullptr)))::value>;
 };
 

--- a/thrift/lib/cpp2/reflection/internal/legacy_reflection-inl-post.h
+++ b/thrift/lib/cpp2/reflection/internal/legacy_reflection-inl-post.h
@@ -395,8 +395,7 @@ struct impl<T, type_class::map<KeyTypeClass, MappedTypeClass>> {
 };
 
 template <typename T, typename TC>
-using is_unknown = std::integral_constant<
-    bool,
+using is_unknown = folly::bool_constant<
     std::is_same<TC, type_class::unknown>::value ||
         (std::is_same<reflect_type_class<T>, type_class::unknown>::value &&
          (std::is_same<TC, type_class::enumeration>::value ||
@@ -404,7 +403,7 @@ using is_unknown = std::integral_constant<
           std::is_same<TC, type_class::variant>::value))>;
 
 template <typename T, typename TC>
-using is_known = std::integral_constant<bool, !is_unknown<T, TC>::value>;
+using is_known = folly::bool_constant<!is_unknown<T, TC>::value>;
 
 template <typename T, typename TC>
 using is_complete = fatal::is_complete<impl<T, TC>>;

--- a/thrift/test/fatal_serialization_common.h
+++ b/thrift/test/fatal_serialization_common.h
@@ -22,6 +22,7 @@
 #include <thrift/lib/cpp2/protocol/CompactProtocol.h>
 
 #include <folly/portability/GTest.h>
+#include <folly/Traits.h>
 
 namespace apache {
 namespace thrift {
@@ -31,7 +32,7 @@ template <typename Reader, typename Writer, bool Printable>
 struct RWPair {
   using reader = Reader;
   using writer = Writer;
-  using printable = std::integral_constant<bool, Printable>;
+  using printable = folly::bool_constant<Printable>;
 };
 
 using protocol_type_pairs = ::testing::Types<


### PR DESCRIPTION
Summary:
- Replace usages of `std::integral_constant<bool, ...>` with folly's
  backport of C++17's `std::bool_constant`, which is spelled
  `folly::bool_constant`. This makes the call sites slightly less wordy.