### PR TITLE
Add option for thrift include path to thrift_* CMake macros

### DIFF
--- a/ThriftLibrary.cmake
+++ b/ThriftLibrary.cmake
@@ -160,21 +160,15 @@ endmacro()
 
 macro(thrift_generate file_name services language options file_path output_path include_prefix)
 
-# Parse optional arguments
-set(thrift_include_directories)
+cmake_parse_arguments(THRIFT_GENERATE   # Prefix
+  "" # Options
+  "" # One Value args
+  "THRIFT_INCLUDE_DIRECTORIES" # Multi-value args
+  "${ARGN}")
 
-set(nextarg)
-foreach(arg ${ARGN})
-  if ("${arg}" STREQUAL "THRIFT_INCLUDE_DIRECTORIES")
-    set(nextarg "THRIFT_INCLUDE_DIRECTORIES")
-  else()
-    if("${nextarg}" STREQUAL "THRIFT_INCLUDE_DIRECTORIES")
-      list(APPEND thrift_include_directories "-I" "${arg}")
-    else()
-      message(FATAL_ERROR "Unexpected parameter '${arg}' call to"
-        "thrift_generate")
-    endif()
-  endif()
+set(thrift_include_directories)
+foreach(dir ${THRIFT_GENERATE_THRIFT_INCLUDE_DIRECTORIES})
+  list(APPEND thrift_include_directories "-I" "${dir}")
 endforeach()
 
 set("${file_name}-${language}-HEADERS"

--- a/ThriftLibrary.cmake
+++ b/ThriftLibrary.cmake
@@ -49,6 +49,7 @@ thrift_generate(
   "${file_path}"
   "${output_path}"
   "${include_prefix}"
+  "${ARGN}"
 )
 bypass_source_check(${${file_name}-${language}-SOURCES})
 add_library(
@@ -107,6 +108,7 @@ thrift_object(
   "${file_path}"
   "${output_path}"
   "${include_prefix}"
+  "${ARGN}"
 )
 add_library(
   "${file_name}-${language}"
@@ -157,6 +159,24 @@ endmacro()
 #
 
 macro(thrift_generate file_name services language options file_path output_path include_prefix)
+
+# Parse optional arguments
+set(thrift_include_directories)
+
+set(nextarg)
+foreach(arg ${ARGN})
+  if ("${arg}" STREQUAL "THRIFT_INCLUDE_DIRECTORIES")
+    set(nextarg "THRIFT_INCLUDE_DIRECTORIES")
+  else()
+    if("${nextarg}" STREQUAL "THRIFT_INCLUDE_DIRECTORIES")
+      list(APPEND thrift_include_directories "-I" "${arg}")
+    else()
+      message(FATAL_ERROR "Unexpected parameter '${arg}' call to"
+        "thrift_generate")
+    endif()
+  endif()
+endforeach()
+
 set("${file_name}-${language}-HEADERS"
   ${output_path}/gen-${language}/${file_name}_constants.h
   ${output_path}/gen-${language}/${file_name}_data.h
@@ -202,6 +222,7 @@ add_custom_command(
   COMMAND ${THRIFT1}
     --gen "${gen_language}:${options}${include_prefix_text}"
     -o ${output_path}
+    ${thrift_include_directories}
     --templates ${THRIFT_TEMPLATES}
     "${file_path}/${file_name}.thrift"
   DEPENDS ${THRIFT1}


### PR DESCRIPTION
To enable the inclusion of thrift files that reside in other directories
we need a way to pass the include paths.

Implemented as an optional argument, allowing compatibility with
existing users of the macro and extensibility for more parameters in the
future.

Test Plan:

Tested with FBThrift as a submodule of LogDevice, moving fb303 from
logdevice/admin/if subdirectory to logdevice/common; this required
changes to that code-base to using the new parameter.
Compiled both with and without thriftpy enabled in the build.