### PR TITLE
Deprecate enable_haddock

### DIFF
--- a/thrift/compiler/generate/t_hs_generator.cc
+++ b/thrift/compiler/generate/t_hs_generator.cc
@@ -52,8 +52,6 @@ class t_hs_generator : public t_oop_generator {
     out_dir_base_ = "gen-hs";
 
     // Set option flags based on parsed options
-    gen_haddock_ =
-        parsed_options.find("enable_haddock") != parsed_options.end();
     use_list_ = parsed_options.find("use_list") != parsed_options.end();
     use_string_ = parsed_options.find("use_string") != parsed_options.end();
     use_strict_text_ =
@@ -65,7 +63,6 @@ class t_hs_generator : public t_oop_generator {
    * Option Flags
    */
 
-  bool gen_haddock_;
   bool use_list_;
   bool use_string_;
   bool use_strict_text_;
@@ -681,8 +678,7 @@ void t_hs_generator::generate_hs_struct_definition(
   const vector<t_field*>& members = tstruct->get_members();
   vector<t_field*>::const_iterator m_iter;
 
-  if (gen_haddock_)
-    indent(out) << "-- | Definition of the " << tname << " struct" << nl;
+  indent(out) << "-- | Definition of the " << tname << " struct" << nl;
   indent(out) << "data " << tname << " = " << tname << nl;
 
   if (members.size() > 0) {
@@ -702,9 +698,8 @@ void t_hs_generator::generate_hs_struct_definition(
         out << "Maybe ";
       }
       out << render_hs_type(m_iter->get_type(), true) << nl;
-      if (gen_haddock_)
-        indent(out) << "  -- ^ " << mname << " field of the " << tname
-                    << " struct" << nl;
+      indent(out) << "  -- ^ " << mname << " field of the " << tname
+                  << " struct" << nl;
     }
     indent(out) << "}";
     indent_down();
@@ -830,10 +825,8 @@ void t_hs_generator::generate_hs_struct_reader(
   string id = tmp("_id");
   string val = tmp("_val");
 
-  if (gen_haddock_) {
-    indent(out) << "-- | Translate a 'Types.ThriftVal' to a '" << sname << "'"
-                << nl;
-  }
+  indent(out) << "-- | Translate a 'Types.ThriftVal' to a '" << sname << "'"
+              << nl;
   indent(out) << "to_" << sname << " :: Types.ThriftVal -> " << sname << nl;
   indent(out) << "to_" << sname << " (Types.TStruct fields) = " << sname << "{"
               << nl;
@@ -888,9 +881,8 @@ void t_hs_generator::generate_hs_struct_reader(
   string tmap = unqualified_type_name(tstruct, "typemap_");
   indent(out) << "to_" << sname << " _ = error \"not a struct\"" << nl;
 
-  if (gen_haddock_)
-    indent(out) << "-- | Read a '" << sname
-                << "' struct with the given 'Thrift.Protocol'" << nl;
+  indent(out) << "-- | Read a '" << sname
+              << "' struct with the given 'Thrift.Protocol'" << nl;
   indent(out) << "read_" << sname
               << " :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO "
               << sname << nl;
@@ -898,8 +890,7 @@ void t_hs_generator::generate_hs_struct_reader(
   out << " <$> Thrift.readVal iprot (Types.T_STRUCT " << tmap << ")" << nl;
 
   // decode
-  if (gen_haddock_)
-    indent(out) << "-- | Deserialize a '" << sname << "' in pure code" << nl;
+  indent(out) << "-- | Deserialize a '" << sname << "' in pure code" << nl;
   indent(out) << "decode_" << sname
               << " :: (Thrift.Protocol p, Thrift.Transport t) => "
               << "p t -> BS.ByteString -> " << sname << nl;
@@ -917,10 +908,8 @@ void t_hs_generator::generate_hs_struct_writer(
   string f = tmp("_f");
   string v = tmp("_v");
 
-  if (gen_haddock_) {
-    indent(out) << "-- | Translate a '" << name << "' to a 'Types.ThriftVal'"
-                << nl;
-  }
+  indent(out) << "-- | Translate a '" << name << "' to a 'Types.ThriftVal'"
+              << nl;
   indent(out) << "from_" << name << " :: " << name << " -> Types.ThriftVal"
               << nl;
   indent(out) << "from_" << name << " record = Types.TStruct $ Map.fromList ";
@@ -1010,9 +999,8 @@ void t_hs_generator::generate_hs_struct_writer(
   indent_down();
 
   // write
-  if (gen_haddock_)
-    indent(out) << "-- | Write a '" << name
-                << "' with the given 'Thrift.Protocol'" << nl;
+  indent(out) << "-- | Write a '" << name
+              << "' with the given 'Thrift.Protocol'" << nl;
   indent(out) << "write_" << name
               << " :: (Thrift.Protocol p, Thrift.Transport t) => p t -> "
               << name << " -> IO ()" << nl;
@@ -1021,8 +1009,7 @@ void t_hs_generator::generate_hs_struct_writer(
   out << name << " record" << nl;
 
   // encode
-  if (gen_haddock_)
-    indent(out) << "-- | Serialize a '" << name << "' in pure code" << nl;
+  indent(out) << "-- | Serialize a '" << name << "' in pure code" << nl;
   indent(out) << "encode_" << name
               << " :: (Thrift.Protocol p, Thrift.Transport t) => p t -> "
               << name << " -> BS.ByteString" << nl;
@@ -1123,8 +1110,7 @@ void t_hs_generator::generate_hs_typemap(ofstream& out, t_struct* tstruct) {
   const auto& fields = tstruct->get_sorted_members();
   vector<t_field*>::const_iterator f_iter;
 
-  if (gen_haddock_)
-    indent(out) << "-- | 'TypeMap' for the '" << name << "' struct" << nl;
+  indent(out) << "-- | 'TypeMap' for the '" << name << "' struct" << nl;
   indent(out) << "typemap_" << name << " :: Types.TypeMap" << nl;
   indent(out) << "typemap_" << name << " = Map.fromList [";
   bool first = true;
@@ -1152,8 +1138,7 @@ void t_hs_generator::generate_hs_default(ofstream& out, t_struct* tstruct) {
   const auto& fields = tstruct->get_sorted_members();
   vector<t_field*>::const_iterator f_iter;
 
-  if (gen_haddock_)
-    indent(out) << "-- | Default values for the '" << name << "' struct" << nl;
+  indent(out) << "-- | Default values for the '" << name << "' struct" << nl;
   indent(out) << fname << " :: " << name << nl;
   indent(out) << fname << " = " << name << "{" << nl;
   indent_up();

--- a/thrift/compiler/test/fixtures/includes/gen-hs/Includes_Types.hs
+++ b/thrift/compiler/test/fixtures/includes/gen-hs/Includes_Types.hs
@@ -54,9 +54,12 @@ type IncludedInt64 = Int.Int64
 
 type TransitiveFoo = Transitive_Types.Foo
 
+-- | Definition of the Included struct
 data Included = Included
   { included_MyIntField :: Int.Int64
+    -- ^ MyIntField field of the Included struct
   , included_MyTransitiveField :: Transitive_Types.Foo
+    -- ^ MyTransitiveField field of the Included struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Included where
   encode = encode_Included
@@ -76,27 +79,35 @@ instance Arbitrary.Arbitrary Included where
     [ if obj == default_Included{included_MyIntField = included_MyIntField obj} then Nothing else Just $ default_Included{included_MyIntField = included_MyIntField obj}
     , if obj == default_Included{included_MyTransitiveField = included_MyTransitiveField obj} then Nothing else Just $ default_Included{included_MyTransitiveField = included_MyTransitiveField obj}
     ]
+-- | Translate a 'Included' to a 'Types.ThriftVal'
 from_Included :: Included -> Types.ThriftVal
 from_Included record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v3 -> Just (1, ("MyIntField",Types.TI64 _v3))) $ included_MyIntField record
   , (\_v3 -> Just (2, ("MyTransitiveField",Transitive_Types.from_Foo _v3))) $ included_MyTransitiveField record
   ]
+-- | Write a 'Included' with the given 'Thrift.Protocol'
 write_Included :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Included -> IO ()
 write_Included oprot record = Thrift.writeVal oprot $ from_Included record
+-- | Serialize a 'Included' in pure code
 encode_Included :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Included -> BS.ByteString
 encode_Included oprot record = Thrift.serializeVal oprot $ from_Included record
+-- | Translate a 'Types.ThriftVal' to a 'Included'
 to_Included :: Types.ThriftVal -> Included
 to_Included (Types.TStruct fields) = Included{
   included_MyIntField = maybe (included_MyIntField default_Included) (\(_,_val5) -> (case _val5 of {Types.TI64 _val6 -> _val6; _ -> error "wrong type"})) (Map.lookup (1) fields),
   included_MyTransitiveField = maybe (included_MyTransitiveField default_Included) (\(_,_val5) -> (case _val5 of {Types.TStruct _val7 -> (Transitive_Types.to_Foo (Types.TStruct _val7)); _ -> error "wrong type"})) (Map.lookup (2) fields)
   }
 to_Included _ = error "not a struct"
+-- | Read a 'Included' struct with the given 'Thrift.Protocol'
 read_Included :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Included
 read_Included iprot = to_Included <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Included)
+-- | Deserialize a 'Included' in pure code
 decode_Included :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Included
 decode_Included iprot bs = to_Included $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Included) bs
+-- | 'TypeMap' for the 'Included' struct
 typemap_Included :: Types.TypeMap
 typemap_Included = Map.fromList [("MyIntField",(1,Types.T_I64)),("MyTransitiveField",(2,(Types.T_STRUCT Transitive_Types.typemap_Foo)))]
+-- | Default values for the 'Included' struct
 default_Included :: Included
 default_Included = Included{
   included_MyIntField = 0,

--- a/thrift/compiler/test/fixtures/includes/gen-hs/Module_Types.hs
+++ b/thrift/compiler/test/fixtures/includes/gen-hs/Module_Types.hs
@@ -50,10 +50,14 @@ import qualified Thrift.Arbitraries as Arbitraries
 import qualified Includes_Types as Includes_Types
 
 
+-- | Definition of the MyStruct struct
 data MyStruct = MyStruct
   { myStruct_MyIncludedField :: Includes_Types.Included
+    -- ^ MyIncludedField field of the MyStruct struct
   , myStruct_MyOtherIncludedField :: Includes_Types.Included
+    -- ^ MyOtherIncludedField field of the MyStruct struct
   , myStruct_MyIncludedInt :: Int.Int64
+    -- ^ MyIncludedInt field of the MyStruct struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable MyStruct where
   encode = encode_MyStruct
@@ -76,16 +80,20 @@ instance Arbitrary.Arbitrary MyStruct where
     , if obj == default_MyStruct{myStruct_MyOtherIncludedField = myStruct_MyOtherIncludedField obj} then Nothing else Just $ default_MyStruct{myStruct_MyOtherIncludedField = myStruct_MyOtherIncludedField obj}
     , if obj == default_MyStruct{myStruct_MyIncludedInt = myStruct_MyIncludedInt obj} then Nothing else Just $ default_MyStruct{myStruct_MyIncludedInt = myStruct_MyIncludedInt obj}
     ]
+-- | Translate a 'MyStruct' to a 'Types.ThriftVal'
 from_MyStruct :: MyStruct -> Types.ThriftVal
 from_MyStruct record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v3 -> Just (1, ("MyIncludedField",Includes_Types.from_Included _v3))) $ myStruct_MyIncludedField record
   , (\_v3 -> Just (2, ("MyOtherIncludedField",Includes_Types.from_Included _v3))) $ myStruct_MyOtherIncludedField record
   , (\_v3 -> Just (3, ("MyIncludedInt",Types.TI64 _v3))) $ myStruct_MyIncludedInt record
   ]
+-- | Write a 'MyStruct' with the given 'Thrift.Protocol'
 write_MyStruct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> MyStruct -> IO ()
 write_MyStruct oprot record = Thrift.writeVal oprot $ from_MyStruct record
+-- | Serialize a 'MyStruct' in pure code
 encode_MyStruct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> MyStruct -> BS.ByteString
 encode_MyStruct oprot record = Thrift.serializeVal oprot $ from_MyStruct record
+-- | Translate a 'Types.ThriftVal' to a 'MyStruct'
 to_MyStruct :: Types.ThriftVal -> MyStruct
 to_MyStruct (Types.TStruct fields) = MyStruct{
   myStruct_MyIncludedField = maybe (myStruct_MyIncludedField default_MyStruct) (\(_,_val5) -> (case _val5 of {Types.TStruct _val6 -> (Includes_Types.to_Included (Types.TStruct _val6)); _ -> error "wrong type"})) (Map.lookup (1) fields),
@@ -93,12 +101,16 @@ to_MyStruct (Types.TStruct fields) = MyStruct{
   myStruct_MyIncludedInt = maybe (myStruct_MyIncludedInt default_MyStruct) (\(_,_val5) -> (case _val5 of {Types.TI64 _val8 -> _val8; _ -> error "wrong type"})) (Map.lookup (3) fields)
   }
 to_MyStruct _ = error "not a struct"
+-- | Read a 'MyStruct' struct with the given 'Thrift.Protocol'
 read_MyStruct :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO MyStruct
 read_MyStruct iprot = to_MyStruct <$> Thrift.readVal iprot (Types.T_STRUCT typemap_MyStruct)
+-- | Deserialize a 'MyStruct' in pure code
 decode_MyStruct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> MyStruct
 decode_MyStruct iprot bs = to_MyStruct $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_MyStruct) bs
+-- | 'TypeMap' for the 'MyStruct' struct
 typemap_MyStruct :: Types.TypeMap
 typemap_MyStruct = Map.fromList [("MyIncludedField",(1,(Types.T_STRUCT Includes_Types.typemap_Included))),("MyOtherIncludedField",(2,(Types.T_STRUCT Includes_Types.typemap_Included))),("MyIncludedInt",(3,Types.T_I64))]
+-- | Default values for the 'MyStruct' struct
 default_MyStruct :: MyStruct
 default_MyStruct = MyStruct{
   myStruct_MyIncludedField = Includes_Types.default_Included{Includes_Types.included_MyIntField = 2, Includes_Types.included_MyTransitiveField = Transitive_Types.default_Foo{Transitive_Types.foo_a = 2}},

--- a/thrift/compiler/test/fixtures/includes/gen-hs/MyService.hs
+++ b/thrift/compiler/test/fixtures/includes/gen-hs/MyService.hs
@@ -55,9 +55,12 @@ import qualified Service_Types
 import qualified MyService_Iface as Iface
 -- HELPER FUNCTIONS AND STRUCTURES --
 
+-- | Definition of the Query_args struct
 data Query_args = Query_args
   { query_args_s :: Module_Types.MyStruct
+    -- ^ s field of the Query_args struct
   , query_args_i :: Includes_Types.Included
+    -- ^ i field of the Query_args struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Query_args where
   encode = encode_Query_args
@@ -77,31 +80,40 @@ instance Arbitrary.Arbitrary Query_args where
     [ if obj == default_Query_args{query_args_s = query_args_s obj} then Nothing else Just $ default_Query_args{query_args_s = query_args_s obj}
     , if obj == default_Query_args{query_args_i = query_args_i obj} then Nothing else Just $ default_Query_args{query_args_i = query_args_i obj}
     ]
+-- | Translate a 'Query_args' to a 'Types.ThriftVal'
 from_Query_args :: Query_args -> Types.ThriftVal
 from_Query_args record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v3 -> Just (1, ("s",Module_Types.from_MyStruct _v3))) $ query_args_s record
   , (\_v3 -> Just (2, ("i",Includes_Types.from_Included _v3))) $ query_args_i record
   ]
+-- | Write a 'Query_args' with the given 'Thrift.Protocol'
 write_Query_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Query_args -> IO ()
 write_Query_args oprot record = Thrift.writeVal oprot $ from_Query_args record
+-- | Serialize a 'Query_args' in pure code
 encode_Query_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Query_args -> BS.ByteString
 encode_Query_args oprot record = Thrift.serializeVal oprot $ from_Query_args record
+-- | Translate a 'Types.ThriftVal' to a 'Query_args'
 to_Query_args :: Types.ThriftVal -> Query_args
 to_Query_args (Types.TStruct fields) = Query_args{
   query_args_s = maybe (query_args_s default_Query_args) (\(_,_val5) -> (case _val5 of {Types.TStruct _val6 -> (Module_Types.to_MyStruct (Types.TStruct _val6)); _ -> error "wrong type"})) (Map.lookup (1) fields),
   query_args_i = maybe (query_args_i default_Query_args) (\(_,_val5) -> (case _val5 of {Types.TStruct _val7 -> (Includes_Types.to_Included (Types.TStruct _val7)); _ -> error "wrong type"})) (Map.lookup (2) fields)
   }
 to_Query_args _ = error "not a struct"
+-- | Read a 'Query_args' struct with the given 'Thrift.Protocol'
 read_Query_args :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Query_args
 read_Query_args iprot = to_Query_args <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Query_args)
+-- | Deserialize a 'Query_args' in pure code
 decode_Query_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Query_args
 decode_Query_args iprot bs = to_Query_args $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Query_args) bs
+-- | 'TypeMap' for the 'Query_args' struct
 typemap_Query_args :: Types.TypeMap
 typemap_Query_args = Map.fromList [("s",(1,(Types.T_STRUCT Module_Types.typemap_MyStruct))),("i",(2,(Types.T_STRUCT Includes_Types.typemap_Included)))]
+-- | Default values for the 'Query_args' struct
 default_Query_args :: Query_args
 default_Query_args = Query_args{
   query_args_s = Module_Types.default_MyStruct,
   query_args_i = Includes_Types.default_Included}
+-- | Definition of the Query_result struct
 data Query_result = Query_result
  deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Query_result where
@@ -114,30 +126,41 @@ instance DeepSeq.NFData Query_result where
     ()
 instance Arbitrary.Arbitrary Query_result where 
   arbitrary = QuickCheck.elements [Query_result]
+-- | Translate a 'Query_result' to a 'Types.ThriftVal'
 from_Query_result :: Query_result -> Types.ThriftVal
 from_Query_result record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   []
+-- | Write a 'Query_result' with the given 'Thrift.Protocol'
 write_Query_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Query_result -> IO ()
 write_Query_result oprot record = Thrift.writeVal oprot $ from_Query_result record
+-- | Serialize a 'Query_result' in pure code
 encode_Query_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Query_result -> BS.ByteString
 encode_Query_result oprot record = Thrift.serializeVal oprot $ from_Query_result record
+-- | Translate a 'Types.ThriftVal' to a 'Query_result'
 to_Query_result :: Types.ThriftVal -> Query_result
 to_Query_result (Types.TStruct fields) = Query_result{
 
   }
 to_Query_result _ = error "not a struct"
+-- | Read a 'Query_result' struct with the given 'Thrift.Protocol'
 read_Query_result :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Query_result
 read_Query_result iprot = to_Query_result <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Query_result)
+-- | Deserialize a 'Query_result' in pure code
 decode_Query_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Query_result
 decode_Query_result iprot bs = to_Query_result $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Query_result) bs
+-- | 'TypeMap' for the 'Query_result' struct
 typemap_Query_result :: Types.TypeMap
 typemap_Query_result = Map.fromList []
+-- | Default values for the 'Query_result' struct
 default_Query_result :: Query_result
 default_Query_result = Query_result{
 }
+-- | Definition of the Has_arg_docs_args struct
 data Has_arg_docs_args = Has_arg_docs_args
   { has_arg_docs_args_s :: Module_Types.MyStruct
+    -- ^ s field of the Has_arg_docs_args struct
   , has_arg_docs_args_i :: Includes_Types.Included
+    -- ^ i field of the Has_arg_docs_args struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Has_arg_docs_args where
   encode = encode_Has_arg_docs_args
@@ -157,31 +180,40 @@ instance Arbitrary.Arbitrary Has_arg_docs_args where
     [ if obj == default_Has_arg_docs_args{has_arg_docs_args_s = has_arg_docs_args_s obj} then Nothing else Just $ default_Has_arg_docs_args{has_arg_docs_args_s = has_arg_docs_args_s obj}
     , if obj == default_Has_arg_docs_args{has_arg_docs_args_i = has_arg_docs_args_i obj} then Nothing else Just $ default_Has_arg_docs_args{has_arg_docs_args_i = has_arg_docs_args_i obj}
     ]
+-- | Translate a 'Has_arg_docs_args' to a 'Types.ThriftVal'
 from_Has_arg_docs_args :: Has_arg_docs_args -> Types.ThriftVal
 from_Has_arg_docs_args record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v17 -> Just (1, ("s",Module_Types.from_MyStruct _v17))) $ has_arg_docs_args_s record
   , (\_v17 -> Just (2, ("i",Includes_Types.from_Included _v17))) $ has_arg_docs_args_i record
   ]
+-- | Write a 'Has_arg_docs_args' with the given 'Thrift.Protocol'
 write_Has_arg_docs_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Has_arg_docs_args -> IO ()
 write_Has_arg_docs_args oprot record = Thrift.writeVal oprot $ from_Has_arg_docs_args record
+-- | Serialize a 'Has_arg_docs_args' in pure code
 encode_Has_arg_docs_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Has_arg_docs_args -> BS.ByteString
 encode_Has_arg_docs_args oprot record = Thrift.serializeVal oprot $ from_Has_arg_docs_args record
+-- | Translate a 'Types.ThriftVal' to a 'Has_arg_docs_args'
 to_Has_arg_docs_args :: Types.ThriftVal -> Has_arg_docs_args
 to_Has_arg_docs_args (Types.TStruct fields) = Has_arg_docs_args{
   has_arg_docs_args_s = maybe (has_arg_docs_args_s default_Has_arg_docs_args) (\(_,_val19) -> (case _val19 of {Types.TStruct _val20 -> (Module_Types.to_MyStruct (Types.TStruct _val20)); _ -> error "wrong type"})) (Map.lookup (1) fields),
   has_arg_docs_args_i = maybe (has_arg_docs_args_i default_Has_arg_docs_args) (\(_,_val19) -> (case _val19 of {Types.TStruct _val21 -> (Includes_Types.to_Included (Types.TStruct _val21)); _ -> error "wrong type"})) (Map.lookup (2) fields)
   }
 to_Has_arg_docs_args _ = error "not a struct"
+-- | Read a 'Has_arg_docs_args' struct with the given 'Thrift.Protocol'
 read_Has_arg_docs_args :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Has_arg_docs_args
 read_Has_arg_docs_args iprot = to_Has_arg_docs_args <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Has_arg_docs_args)
+-- | Deserialize a 'Has_arg_docs_args' in pure code
 decode_Has_arg_docs_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Has_arg_docs_args
 decode_Has_arg_docs_args iprot bs = to_Has_arg_docs_args $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Has_arg_docs_args) bs
+-- | 'TypeMap' for the 'Has_arg_docs_args' struct
 typemap_Has_arg_docs_args :: Types.TypeMap
 typemap_Has_arg_docs_args = Map.fromList [("s",(1,(Types.T_STRUCT Module_Types.typemap_MyStruct))),("i",(2,(Types.T_STRUCT Includes_Types.typemap_Included)))]
+-- | Default values for the 'Has_arg_docs_args' struct
 default_Has_arg_docs_args :: Has_arg_docs_args
 default_Has_arg_docs_args = Has_arg_docs_args{
   has_arg_docs_args_s = Module_Types.default_MyStruct,
   has_arg_docs_args_i = Includes_Types.default_Included}
+-- | Definition of the Has_arg_docs_result struct
 data Has_arg_docs_result = Has_arg_docs_result
  deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Has_arg_docs_result where
@@ -194,24 +226,32 @@ instance DeepSeq.NFData Has_arg_docs_result where
     ()
 instance Arbitrary.Arbitrary Has_arg_docs_result where 
   arbitrary = QuickCheck.elements [Has_arg_docs_result]
+-- | Translate a 'Has_arg_docs_result' to a 'Types.ThriftVal'
 from_Has_arg_docs_result :: Has_arg_docs_result -> Types.ThriftVal
 from_Has_arg_docs_result record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   []
+-- | Write a 'Has_arg_docs_result' with the given 'Thrift.Protocol'
 write_Has_arg_docs_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Has_arg_docs_result -> IO ()
 write_Has_arg_docs_result oprot record = Thrift.writeVal oprot $ from_Has_arg_docs_result record
+-- | Serialize a 'Has_arg_docs_result' in pure code
 encode_Has_arg_docs_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Has_arg_docs_result -> BS.ByteString
 encode_Has_arg_docs_result oprot record = Thrift.serializeVal oprot $ from_Has_arg_docs_result record
+-- | Translate a 'Types.ThriftVal' to a 'Has_arg_docs_result'
 to_Has_arg_docs_result :: Types.ThriftVal -> Has_arg_docs_result
 to_Has_arg_docs_result (Types.TStruct fields) = Has_arg_docs_result{
 
   }
 to_Has_arg_docs_result _ = error "not a struct"
+-- | Read a 'Has_arg_docs_result' struct with the given 'Thrift.Protocol'
 read_Has_arg_docs_result :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Has_arg_docs_result
 read_Has_arg_docs_result iprot = to_Has_arg_docs_result <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Has_arg_docs_result)
+-- | Deserialize a 'Has_arg_docs_result' in pure code
 decode_Has_arg_docs_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Has_arg_docs_result
 decode_Has_arg_docs_result iprot bs = to_Has_arg_docs_result $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Has_arg_docs_result) bs
+-- | 'TypeMap' for the 'Has_arg_docs_result' struct
 typemap_Has_arg_docs_result :: Types.TypeMap
 typemap_Has_arg_docs_result = Map.fromList []
+-- | Default values for the 'Has_arg_docs_result' struct
 default_Has_arg_docs_result :: Has_arg_docs_result
 default_Has_arg_docs_result = Has_arg_docs_result{
 }

--- a/thrift/compiler/test/fixtures/includes/gen-hs/Transitive_Types.hs
+++ b/thrift/compiler/test/fixtures/includes/gen-hs/Transitive_Types.hs
@@ -48,8 +48,10 @@ import qualified Thrift.Serializable as Serializable
 import qualified Thrift.Arbitraries as Arbitraries
 
 
+-- | Definition of the Foo struct
 data Foo = Foo
   { foo_a :: Int.Int64
+    -- ^ a field of the Foo struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Foo where
   encode = encode_Foo
@@ -66,25 +68,33 @@ instance Arbitrary.Arbitrary Foo where
              | otherwise = Maybe.catMaybes
     [ if obj == default_Foo{foo_a = foo_a obj} then Nothing else Just $ default_Foo{foo_a = foo_a obj}
     ]
+-- | Translate a 'Foo' to a 'Types.ThriftVal'
 from_Foo :: Foo -> Types.ThriftVal
 from_Foo record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v3 -> Just (1, ("a",Types.TI64 _v3))) $ foo_a record
   ]
+-- | Write a 'Foo' with the given 'Thrift.Protocol'
 write_Foo :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Foo -> IO ()
 write_Foo oprot record = Thrift.writeVal oprot $ from_Foo record
+-- | Serialize a 'Foo' in pure code
 encode_Foo :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Foo -> BS.ByteString
 encode_Foo oprot record = Thrift.serializeVal oprot $ from_Foo record
+-- | Translate a 'Types.ThriftVal' to a 'Foo'
 to_Foo :: Types.ThriftVal -> Foo
 to_Foo (Types.TStruct fields) = Foo{
   foo_a = maybe (foo_a default_Foo) (\(_,_val5) -> (case _val5 of {Types.TI64 _val6 -> _val6; _ -> error "wrong type"})) (Map.lookup (1) fields)
   }
 to_Foo _ = error "not a struct"
+-- | Read a 'Foo' struct with the given 'Thrift.Protocol'
 read_Foo :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Foo
 read_Foo iprot = to_Foo <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Foo)
+-- | Deserialize a 'Foo' in pure code
 decode_Foo :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Foo
 decode_Foo iprot bs = to_Foo $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Foo) bs
+-- | 'TypeMap' for the 'Foo' struct
 typemap_Foo :: Types.TypeMap
 typemap_Foo = Map.fromList [("a",(1,Types.T_I64))]
+-- | Default values for the 'Foo' struct
 default_Foo :: Foo
 default_Foo = Foo{
   foo_a = 2}

--- a/thrift/compiler/test/fixtures/namespace/gen-hs/Module_Types.hs
+++ b/thrift/compiler/test/fixtures/namespace/gen-hs/Module_Types.hs
@@ -48,8 +48,10 @@ import qualified Thrift.Serializable as Serializable
 import qualified Thrift.Arbitraries as Arbitraries
 
 
+-- | Definition of the Foo struct
 data Foo = Foo
   { foo_MyInt :: Int.Int64
+    -- ^ MyInt field of the Foo struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Foo where
   encode = encode_Foo
@@ -66,25 +68,33 @@ instance Arbitrary.Arbitrary Foo where
              | otherwise = Maybe.catMaybes
     [ if obj == default_Foo{foo_MyInt = foo_MyInt obj} then Nothing else Just $ default_Foo{foo_MyInt = foo_MyInt obj}
     ]
+-- | Translate a 'Foo' to a 'Types.ThriftVal'
 from_Foo :: Foo -> Types.ThriftVal
 from_Foo record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v3 -> Just (1, ("MyInt",Types.TI64 _v3))) $ foo_MyInt record
   ]
+-- | Write a 'Foo' with the given 'Thrift.Protocol'
 write_Foo :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Foo -> IO ()
 write_Foo oprot record = Thrift.writeVal oprot $ from_Foo record
+-- | Serialize a 'Foo' in pure code
 encode_Foo :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Foo -> BS.ByteString
 encode_Foo oprot record = Thrift.serializeVal oprot $ from_Foo record
+-- | Translate a 'Types.ThriftVal' to a 'Foo'
 to_Foo :: Types.ThriftVal -> Foo
 to_Foo (Types.TStruct fields) = Foo{
   foo_MyInt = maybe (foo_MyInt default_Foo) (\(_,_val5) -> (case _val5 of {Types.TI64 _val6 -> _val6; _ -> error "wrong type"})) (Map.lookup (1) fields)
   }
 to_Foo _ = error "not a struct"
+-- | Read a 'Foo' struct with the given 'Thrift.Protocol'
 read_Foo :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Foo
 read_Foo iprot = to_Foo <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Foo)
+-- | Deserialize a 'Foo' in pure code
 decode_Foo :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Foo
 decode_Foo iprot bs = to_Foo $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Foo) bs
+-- | 'TypeMap' for the 'Foo' struct
 typemap_Foo :: Types.TypeMap
 typemap_Foo = Map.fromList [("MyInt",(1,Types.T_I64))]
+-- | Default values for the 'Foo' struct
 default_Foo :: Foo
 default_Foo = Foo{
   foo_MyInt = 0}

--- a/thrift/compiler/test/fixtures/namespace/gen-hs/My/Namespacing/Extend/Test/ExtendTestService.hs
+++ b/thrift/compiler/test/fixtures/namespace/gen-hs/My/Namespacing/Extend/Test/ExtendTestService.hs
@@ -55,8 +55,10 @@ import qualified My.Namespacing.Extend.Test.Extend_Types
 import qualified My.Namespacing.Extend.Test.ExtendTestService_Iface as Iface
 -- HELPER FUNCTIONS AND STRUCTURES --
 
+-- | Definition of the Check_args struct
 data Check_args = Check_args
   { check_args_struct1 :: Hsmodule_Types.HsFoo
+    -- ^ struct1 field of the Check_args struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Check_args where
   encode = encode_Check_args
@@ -73,30 +75,40 @@ instance Arbitrary.Arbitrary Check_args where
              | otherwise = Maybe.catMaybes
     [ if obj == default_Check_args{check_args_struct1 = check_args_struct1 obj} then Nothing else Just $ default_Check_args{check_args_struct1 = check_args_struct1 obj}
     ]
+-- | Translate a 'Check_args' to a 'Types.ThriftVal'
 from_Check_args :: Check_args -> Types.ThriftVal
 from_Check_args record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v3 -> Just (1, ("struct1",Hsmodule_Types.from_HsFoo _v3))) $ check_args_struct1 record
   ]
+-- | Write a 'Check_args' with the given 'Thrift.Protocol'
 write_Check_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Check_args -> IO ()
 write_Check_args oprot record = Thrift.writeVal oprot $ from_Check_args record
+-- | Serialize a 'Check_args' in pure code
 encode_Check_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Check_args -> BS.ByteString
 encode_Check_args oprot record = Thrift.serializeVal oprot $ from_Check_args record
+-- | Translate a 'Types.ThriftVal' to a 'Check_args'
 to_Check_args :: Types.ThriftVal -> Check_args
 to_Check_args (Types.TStruct fields) = Check_args{
   check_args_struct1 = maybe (check_args_struct1 default_Check_args) (\(_,_val5) -> (case _val5 of {Types.TStruct _val6 -> (Hsmodule_Types.to_HsFoo (Types.TStruct _val6)); _ -> error "wrong type"})) (Map.lookup (1) fields)
   }
 to_Check_args _ = error "not a struct"
+-- | Read a 'Check_args' struct with the given 'Thrift.Protocol'
 read_Check_args :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Check_args
 read_Check_args iprot = to_Check_args <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Check_args)
+-- | Deserialize a 'Check_args' in pure code
 decode_Check_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Check_args
 decode_Check_args iprot bs = to_Check_args $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Check_args) bs
+-- | 'TypeMap' for the 'Check_args' struct
 typemap_Check_args :: Types.TypeMap
 typemap_Check_args = Map.fromList [("struct1",(1,(Types.T_STRUCT Hsmodule_Types.typemap_HsFoo)))]
+-- | Default values for the 'Check_args' struct
 default_Check_args :: Check_args
 default_Check_args = Check_args{
   check_args_struct1 = Hsmodule_Types.default_HsFoo}
+-- | Definition of the Check_result struct
 data Check_result = Check_result
   { check_result_success :: Bool
+    -- ^ success field of the Check_result struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Check_result where
   encode = encode_Check_result
@@ -113,25 +125,33 @@ instance Arbitrary.Arbitrary Check_result where
              | otherwise = Maybe.catMaybes
     [ if obj == default_Check_result{check_result_success = check_result_success obj} then Nothing else Just $ default_Check_result{check_result_success = check_result_success obj}
     ]
+-- | Translate a 'Check_result' to a 'Types.ThriftVal'
 from_Check_result :: Check_result -> Types.ThriftVal
 from_Check_result record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v10 -> Just (0, ("success",Types.TBool _v10))) $ check_result_success record
   ]
+-- | Write a 'Check_result' with the given 'Thrift.Protocol'
 write_Check_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Check_result -> IO ()
 write_Check_result oprot record = Thrift.writeVal oprot $ from_Check_result record
+-- | Serialize a 'Check_result' in pure code
 encode_Check_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Check_result -> BS.ByteString
 encode_Check_result oprot record = Thrift.serializeVal oprot $ from_Check_result record
+-- | Translate a 'Types.ThriftVal' to a 'Check_result'
 to_Check_result :: Types.ThriftVal -> Check_result
 to_Check_result (Types.TStruct fields) = Check_result{
   check_result_success = maybe (check_result_success default_Check_result) (\(_,_val12) -> (case _val12 of {Types.TBool _val13 -> _val13; _ -> error "wrong type"})) (Map.lookup (0) fields)
   }
 to_Check_result _ = error "not a struct"
+-- | Read a 'Check_result' struct with the given 'Thrift.Protocol'
 read_Check_result :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Check_result
 read_Check_result iprot = to_Check_result <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Check_result)
+-- | Deserialize a 'Check_result' in pure code
 decode_Check_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Check_result
 decode_Check_result iprot bs = to_Check_result $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Check_result) bs
+-- | 'TypeMap' for the 'Check_result' struct
 typemap_Check_result :: Types.TypeMap
 typemap_Check_result = Map.fromList [("success",(0,Types.T_BOOL))]
+-- | Default values for the 'Check_result' struct
 default_Check_result :: Check_result
 default_Check_result = Check_result{
   check_result_success = False}

--- a/thrift/compiler/test/fixtures/namespace/gen-hs/My/Namespacing/Test/HsTestService.hs
+++ b/thrift/compiler/test/fixtures/namespace/gen-hs/My/Namespacing/Test/HsTestService.hs
@@ -52,8 +52,10 @@ import qualified My.Namespacing.Test.Hsmodule_Types
 import qualified My.Namespacing.Test.HsTestService_Iface as Iface
 -- HELPER FUNCTIONS AND STRUCTURES --
 
+-- | Definition of the Init_args struct
 data Init_args = Init_args
   { init_args_int1 :: Int.Int64
+    -- ^ int1 field of the Init_args struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Init_args where
   encode = encode_Init_args
@@ -70,30 +72,40 @@ instance Arbitrary.Arbitrary Init_args where
              | otherwise = Maybe.catMaybes
     [ if obj == default_Init_args{init_args_int1 = init_args_int1 obj} then Nothing else Just $ default_Init_args{init_args_int1 = init_args_int1 obj}
     ]
+-- | Translate a 'Init_args' to a 'Types.ThriftVal'
 from_Init_args :: Init_args -> Types.ThriftVal
 from_Init_args record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v10 -> Just (1, ("int1",Types.TI64 _v10))) $ init_args_int1 record
   ]
+-- | Write a 'Init_args' with the given 'Thrift.Protocol'
 write_Init_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Init_args -> IO ()
 write_Init_args oprot record = Thrift.writeVal oprot $ from_Init_args record
+-- | Serialize a 'Init_args' in pure code
 encode_Init_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Init_args -> BS.ByteString
 encode_Init_args oprot record = Thrift.serializeVal oprot $ from_Init_args record
+-- | Translate a 'Types.ThriftVal' to a 'Init_args'
 to_Init_args :: Types.ThriftVal -> Init_args
 to_Init_args (Types.TStruct fields) = Init_args{
   init_args_int1 = maybe (init_args_int1 default_Init_args) (\(_,_val12) -> (case _val12 of {Types.TI64 _val13 -> _val13; _ -> error "wrong type"})) (Map.lookup (1) fields)
   }
 to_Init_args _ = error "not a struct"
+-- | Read a 'Init_args' struct with the given 'Thrift.Protocol'
 read_Init_args :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Init_args
 read_Init_args iprot = to_Init_args <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Init_args)
+-- | Deserialize a 'Init_args' in pure code
 decode_Init_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Init_args
 decode_Init_args iprot bs = to_Init_args $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Init_args) bs
+-- | 'TypeMap' for the 'Init_args' struct
 typemap_Init_args :: Types.TypeMap
 typemap_Init_args = Map.fromList [("int1",(1,Types.T_I64))]
+-- | Default values for the 'Init_args' struct
 default_Init_args :: Init_args
 default_Init_args = Init_args{
   init_args_int1 = 0}
+-- | Definition of the Init_result struct
 data Init_result = Init_result
   { init_result_success :: Int.Int64
+    -- ^ success field of the Init_result struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Init_result where
   encode = encode_Init_result
@@ -110,25 +122,33 @@ instance Arbitrary.Arbitrary Init_result where
              | otherwise = Maybe.catMaybes
     [ if obj == default_Init_result{init_result_success = init_result_success obj} then Nothing else Just $ default_Init_result{init_result_success = init_result_success obj}
     ]
+-- | Translate a 'Init_result' to a 'Types.ThriftVal'
 from_Init_result :: Init_result -> Types.ThriftVal
 from_Init_result record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v17 -> Just (0, ("success",Types.TI64 _v17))) $ init_result_success record
   ]
+-- | Write a 'Init_result' with the given 'Thrift.Protocol'
 write_Init_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Init_result -> IO ()
 write_Init_result oprot record = Thrift.writeVal oprot $ from_Init_result record
+-- | Serialize a 'Init_result' in pure code
 encode_Init_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Init_result -> BS.ByteString
 encode_Init_result oprot record = Thrift.serializeVal oprot $ from_Init_result record
+-- | Translate a 'Types.ThriftVal' to a 'Init_result'
 to_Init_result :: Types.ThriftVal -> Init_result
 to_Init_result (Types.TStruct fields) = Init_result{
   init_result_success = maybe (init_result_success default_Init_result) (\(_,_val19) -> (case _val19 of {Types.TI64 _val20 -> _val20; _ -> error "wrong type"})) (Map.lookup (0) fields)
   }
 to_Init_result _ = error "not a struct"
+-- | Read a 'Init_result' struct with the given 'Thrift.Protocol'
 read_Init_result :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Init_result
 read_Init_result iprot = to_Init_result <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Init_result)
+-- | Deserialize a 'Init_result' in pure code
 decode_Init_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Init_result
 decode_Init_result iprot bs = to_Init_result $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Init_result) bs
+-- | 'TypeMap' for the 'Init_result' struct
 typemap_Init_result :: Types.TypeMap
 typemap_Init_result = Map.fromList [("success",(0,Types.T_I64))]
+-- | Default values for the 'Init_result' struct
 default_Init_result :: Init_result
 default_Init_result = Init_result{
   init_result_success = 0}

--- a/thrift/compiler/test/fixtures/namespace/gen-hs/My/Namespacing/Test/Hsmodule_Types.hs
+++ b/thrift/compiler/test/fixtures/namespace/gen-hs/My/Namespacing/Test/Hsmodule_Types.hs
@@ -48,8 +48,10 @@ import qualified Thrift.Serializable as Serializable
 import qualified Thrift.Arbitraries as Arbitraries
 
 
+-- | Definition of the HsFoo struct
 data HsFoo = HsFoo
   { hsFoo_MyInt :: Int.Int64
+    -- ^ MyInt field of the HsFoo struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable HsFoo where
   encode = encode_HsFoo
@@ -66,25 +68,33 @@ instance Arbitrary.Arbitrary HsFoo where
              | otherwise = Maybe.catMaybes
     [ if obj == default_HsFoo{hsFoo_MyInt = hsFoo_MyInt obj} then Nothing else Just $ default_HsFoo{hsFoo_MyInt = hsFoo_MyInt obj}
     ]
+-- | Translate a 'HsFoo' to a 'Types.ThriftVal'
 from_HsFoo :: HsFoo -> Types.ThriftVal
 from_HsFoo record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v3 -> Just (1, ("MyInt",Types.TI64 _v3))) $ hsFoo_MyInt record
   ]
+-- | Write a 'HsFoo' with the given 'Thrift.Protocol'
 write_HsFoo :: (Thrift.Protocol p, Thrift.Transport t) => p t -> HsFoo -> IO ()
 write_HsFoo oprot record = Thrift.writeVal oprot $ from_HsFoo record
+-- | Serialize a 'HsFoo' in pure code
 encode_HsFoo :: (Thrift.Protocol p, Thrift.Transport t) => p t -> HsFoo -> BS.ByteString
 encode_HsFoo oprot record = Thrift.serializeVal oprot $ from_HsFoo record
+-- | Translate a 'Types.ThriftVal' to a 'HsFoo'
 to_HsFoo :: Types.ThriftVal -> HsFoo
 to_HsFoo (Types.TStruct fields) = HsFoo{
   hsFoo_MyInt = maybe (hsFoo_MyInt default_HsFoo) (\(_,_val5) -> (case _val5 of {Types.TI64 _val6 -> _val6; _ -> error "wrong type"})) (Map.lookup (1) fields)
   }
 to_HsFoo _ = error "not a struct"
+-- | Read a 'HsFoo' struct with the given 'Thrift.Protocol'
 read_HsFoo :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO HsFoo
 read_HsFoo iprot = to_HsFoo <$> Thrift.readVal iprot (Types.T_STRUCT typemap_HsFoo)
+-- | Deserialize a 'HsFoo' in pure code
 decode_HsFoo :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> HsFoo
 decode_HsFoo iprot bs = to_HsFoo $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_HsFoo) bs
+-- | 'TypeMap' for the 'HsFoo' struct
 typemap_HsFoo :: Types.TypeMap
 typemap_HsFoo = Map.fromList [("MyInt",(1,Types.T_I64))]
+-- | Default values for the 'HsFoo' struct
 default_HsFoo :: HsFoo
 default_HsFoo = HsFoo{
   hsFoo_MyInt = 0}

--- a/thrift/compiler/test/fixtures/namespace/gen-hs/TestService.hs
+++ b/thrift/compiler/test/fixtures/namespace/gen-hs/TestService.hs
@@ -52,8 +52,10 @@ import qualified Module_Types
 import qualified TestService_Iface as Iface
 -- HELPER FUNCTIONS AND STRUCTURES --
 
+-- | Definition of the Init_args struct
 data Init_args = Init_args
   { init_args_int1 :: Int.Int64
+    -- ^ int1 field of the Init_args struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Init_args where
   encode = encode_Init_args
@@ -70,30 +72,40 @@ instance Arbitrary.Arbitrary Init_args where
              | otherwise = Maybe.catMaybes
     [ if obj == default_Init_args{init_args_int1 = init_args_int1 obj} then Nothing else Just $ default_Init_args{init_args_int1 = init_args_int1 obj}
     ]
+-- | Translate a 'Init_args' to a 'Types.ThriftVal'
 from_Init_args :: Init_args -> Types.ThriftVal
 from_Init_args record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v10 -> Just (1, ("int1",Types.TI64 _v10))) $ init_args_int1 record
   ]
+-- | Write a 'Init_args' with the given 'Thrift.Protocol'
 write_Init_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Init_args -> IO ()
 write_Init_args oprot record = Thrift.writeVal oprot $ from_Init_args record
+-- | Serialize a 'Init_args' in pure code
 encode_Init_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Init_args -> BS.ByteString
 encode_Init_args oprot record = Thrift.serializeVal oprot $ from_Init_args record
+-- | Translate a 'Types.ThriftVal' to a 'Init_args'
 to_Init_args :: Types.ThriftVal -> Init_args
 to_Init_args (Types.TStruct fields) = Init_args{
   init_args_int1 = maybe (init_args_int1 default_Init_args) (\(_,_val12) -> (case _val12 of {Types.TI64 _val13 -> _val13; _ -> error "wrong type"})) (Map.lookup (1) fields)
   }
 to_Init_args _ = error "not a struct"
+-- | Read a 'Init_args' struct with the given 'Thrift.Protocol'
 read_Init_args :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Init_args
 read_Init_args iprot = to_Init_args <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Init_args)
+-- | Deserialize a 'Init_args' in pure code
 decode_Init_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Init_args
 decode_Init_args iprot bs = to_Init_args $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Init_args) bs
+-- | 'TypeMap' for the 'Init_args' struct
 typemap_Init_args :: Types.TypeMap
 typemap_Init_args = Map.fromList [("int1",(1,Types.T_I64))]
+-- | Default values for the 'Init_args' struct
 default_Init_args :: Init_args
 default_Init_args = Init_args{
   init_args_int1 = 0}
+-- | Definition of the Init_result struct
 data Init_result = Init_result
   { init_result_success :: Int.Int64
+    -- ^ success field of the Init_result struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Init_result where
   encode = encode_Init_result
@@ -110,25 +122,33 @@ instance Arbitrary.Arbitrary Init_result where
              | otherwise = Maybe.catMaybes
     [ if obj == default_Init_result{init_result_success = init_result_success obj} then Nothing else Just $ default_Init_result{init_result_success = init_result_success obj}
     ]
+-- | Translate a 'Init_result' to a 'Types.ThriftVal'
 from_Init_result :: Init_result -> Types.ThriftVal
 from_Init_result record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v17 -> Just (0, ("success",Types.TI64 _v17))) $ init_result_success record
   ]
+-- | Write a 'Init_result' with the given 'Thrift.Protocol'
 write_Init_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Init_result -> IO ()
 write_Init_result oprot record = Thrift.writeVal oprot $ from_Init_result record
+-- | Serialize a 'Init_result' in pure code
 encode_Init_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Init_result -> BS.ByteString
 encode_Init_result oprot record = Thrift.serializeVal oprot $ from_Init_result record
+-- | Translate a 'Types.ThriftVal' to a 'Init_result'
 to_Init_result :: Types.ThriftVal -> Init_result
 to_Init_result (Types.TStruct fields) = Init_result{
   init_result_success = maybe (init_result_success default_Init_result) (\(_,_val19) -> (case _val19 of {Types.TI64 _val20 -> _val20; _ -> error "wrong type"})) (Map.lookup (0) fields)
   }
 to_Init_result _ = error "not a struct"
+-- | Read a 'Init_result' struct with the given 'Thrift.Protocol'
 read_Init_result :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Init_result
 read_Init_result iprot = to_Init_result <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Init_result)
+-- | Deserialize a 'Init_result' in pure code
 decode_Init_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Init_result
 decode_Init_result iprot bs = to_Init_result $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Init_result) bs
+-- | 'TypeMap' for the 'Init_result' struct
 typemap_Init_result :: Types.TypeMap
 typemap_Init_result = Map.fromList [("success",(0,Types.T_I64))]
+-- | Default values for the 'Init_result' struct
 default_Init_result :: Init_result
 default_Init_result = Init_result{
   init_result_success = 0}

--- a/thrift/compiler/test/fixtures/qualified/gen-hs/Module0_Types.hs
+++ b/thrift/compiler/test/fixtures/qualified/gen-hs/Module0_Types.hs
@@ -81,9 +81,12 @@ instance DeepSeq.NFData Enum where
   rnf x = x `seq` ()
 instance Arbitrary.Arbitrary Enum where
   arbitrary = QuickCheck.elements (enumFromTo minBound maxBound)
+-- | Definition of the Struct struct
 data Struct = Struct
   { struct_first :: Int.Int32
+    -- ^ first field of the Struct struct
   , struct_second :: LT.Text
+    -- ^ second field of the Struct struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Struct where
   encode = encode_Struct
@@ -103,27 +106,35 @@ instance Arbitrary.Arbitrary Struct where
     [ if obj == default_Struct{struct_first = struct_first obj} then Nothing else Just $ default_Struct{struct_first = struct_first obj}
     , if obj == default_Struct{struct_second = struct_second obj} then Nothing else Just $ default_Struct{struct_second = struct_second obj}
     ]
+-- | Translate a 'Struct' to a 'Types.ThriftVal'
 from_Struct :: Struct -> Types.ThriftVal
 from_Struct record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v3 -> Just (1, ("first",Types.TI32 _v3))) $ struct_first record
   , (\_v3 -> Just (2, ("second",Types.TString $ Encoding.encodeUtf8 _v3))) $ struct_second record
   ]
+-- | Write a 'Struct' with the given 'Thrift.Protocol'
 write_Struct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Struct -> IO ()
 write_Struct oprot record = Thrift.writeVal oprot $ from_Struct record
+-- | Serialize a 'Struct' in pure code
 encode_Struct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Struct -> BS.ByteString
 encode_Struct oprot record = Thrift.serializeVal oprot $ from_Struct record
+-- | Translate a 'Types.ThriftVal' to a 'Struct'
 to_Struct :: Types.ThriftVal -> Struct
 to_Struct (Types.TStruct fields) = Struct{
   struct_first = maybe (struct_first default_Struct) (\(_,_val5) -> (case _val5 of {Types.TI32 _val6 -> _val6; _ -> error "wrong type"})) (Map.lookup (1) fields),
   struct_second = maybe (struct_second default_Struct) (\(_,_val5) -> (case _val5 of {Types.TString _val7 -> Encoding.decodeUtf8 _val7; _ -> error "wrong type"})) (Map.lookup (2) fields)
   }
 to_Struct _ = error "not a struct"
+-- | Read a 'Struct' struct with the given 'Thrift.Protocol'
 read_Struct :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Struct
 read_Struct iprot = to_Struct <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Struct)
+-- | Deserialize a 'Struct' in pure code
 decode_Struct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Struct
 decode_Struct iprot bs = to_Struct $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Struct) bs
+-- | 'TypeMap' for the 'Struct' struct
 typemap_Struct :: Types.TypeMap
 typemap_Struct = Map.fromList [("first",(1,Types.T_I32)),("second",(2,Types.T_STRING))]
+-- | Default values for the 'Struct' struct
 default_Struct :: Struct
 default_Struct = Struct{
   struct_first = 0,

--- a/thrift/compiler/test/fixtures/qualified/gen-hs/Module1_Types.hs
+++ b/thrift/compiler/test/fixtures/qualified/gen-hs/Module1_Types.hs
@@ -81,9 +81,12 @@ instance DeepSeq.NFData Enum where
   rnf x = x `seq` ()
 instance Arbitrary.Arbitrary Enum where
   arbitrary = QuickCheck.elements (enumFromTo minBound maxBound)
+-- | Definition of the Struct struct
 data Struct = Struct
   { struct_first :: Int.Int32
+    -- ^ first field of the Struct struct
   , struct_second :: LT.Text
+    -- ^ second field of the Struct struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Struct where
   encode = encode_Struct
@@ -103,27 +106,35 @@ instance Arbitrary.Arbitrary Struct where
     [ if obj == default_Struct{struct_first = struct_first obj} then Nothing else Just $ default_Struct{struct_first = struct_first obj}
     , if obj == default_Struct{struct_second = struct_second obj} then Nothing else Just $ default_Struct{struct_second = struct_second obj}
     ]
+-- | Translate a 'Struct' to a 'Types.ThriftVal'
 from_Struct :: Struct -> Types.ThriftVal
 from_Struct record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v3 -> Just (1, ("first",Types.TI32 _v3))) $ struct_first record
   , (\_v3 -> Just (2, ("second",Types.TString $ Encoding.encodeUtf8 _v3))) $ struct_second record
   ]
+-- | Write a 'Struct' with the given 'Thrift.Protocol'
 write_Struct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Struct -> IO ()
 write_Struct oprot record = Thrift.writeVal oprot $ from_Struct record
+-- | Serialize a 'Struct' in pure code
 encode_Struct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Struct -> BS.ByteString
 encode_Struct oprot record = Thrift.serializeVal oprot $ from_Struct record
+-- | Translate a 'Types.ThriftVal' to a 'Struct'
 to_Struct :: Types.ThriftVal -> Struct
 to_Struct (Types.TStruct fields) = Struct{
   struct_first = maybe (struct_first default_Struct) (\(_,_val5) -> (case _val5 of {Types.TI32 _val6 -> _val6; _ -> error "wrong type"})) (Map.lookup (1) fields),
   struct_second = maybe (struct_second default_Struct) (\(_,_val5) -> (case _val5 of {Types.TString _val7 -> Encoding.decodeUtf8 _val7; _ -> error "wrong type"})) (Map.lookup (2) fields)
   }
 to_Struct _ = error "not a struct"
+-- | Read a 'Struct' struct with the given 'Thrift.Protocol'
 read_Struct :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Struct
 read_Struct iprot = to_Struct <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Struct)
+-- | Deserialize a 'Struct' in pure code
 decode_Struct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Struct
 decode_Struct iprot bs = to_Struct $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Struct) bs
+-- | 'TypeMap' for the 'Struct' struct
 typemap_Struct :: Types.TypeMap
 typemap_Struct = Map.fromList [("first",(1,Types.T_I32)),("second",(2,Types.T_STRING))]
+-- | Default values for the 'Struct' struct
 default_Struct :: Struct
 default_Struct = Struct{
   struct_first = 0,

--- a/thrift/compiler/test/fixtures/qualified/gen-hs/Module2_Types.hs
+++ b/thrift/compiler/test/fixtures/qualified/gen-hs/Module2_Types.hs
@@ -51,9 +51,12 @@ import qualified Module0_Types as Module0_Types
 import qualified Module1_Types as Module1_Types
 
 
+-- | Definition of the Struct struct
 data Struct = Struct
   { struct_first :: Module0_Types.Struct
+    -- ^ first field of the Struct struct
   , struct_second :: Module1_Types.Struct
+    -- ^ second field of the Struct struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Struct where
   encode = encode_Struct
@@ -73,34 +76,45 @@ instance Arbitrary.Arbitrary Struct where
     [ if obj == default_Struct{struct_first = struct_first obj} then Nothing else Just $ default_Struct{struct_first = struct_first obj}
     , if obj == default_Struct{struct_second = struct_second obj} then Nothing else Just $ default_Struct{struct_second = struct_second obj}
     ]
+-- | Translate a 'Struct' to a 'Types.ThriftVal'
 from_Struct :: Struct -> Types.ThriftVal
 from_Struct record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v3 -> Just (1, ("first",Module0_Types.from_Struct _v3))) $ struct_first record
   , (\_v3 -> Just (2, ("second",Module1_Types.from_Struct _v3))) $ struct_second record
   ]
+-- | Write a 'Struct' with the given 'Thrift.Protocol'
 write_Struct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Struct -> IO ()
 write_Struct oprot record = Thrift.writeVal oprot $ from_Struct record
+-- | Serialize a 'Struct' in pure code
 encode_Struct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Struct -> BS.ByteString
 encode_Struct oprot record = Thrift.serializeVal oprot $ from_Struct record
+-- | Translate a 'Types.ThriftVal' to a 'Struct'
 to_Struct :: Types.ThriftVal -> Struct
 to_Struct (Types.TStruct fields) = Struct{
   struct_first = maybe (struct_first default_Struct) (\(_,_val5) -> (case _val5 of {Types.TStruct _val6 -> (Module0_Types.to_Struct (Types.TStruct _val6)); _ -> error "wrong type"})) (Map.lookup (1) fields),
   struct_second = maybe (struct_second default_Struct) (\(_,_val5) -> (case _val5 of {Types.TStruct _val7 -> (Module1_Types.to_Struct (Types.TStruct _val7)); _ -> error "wrong type"})) (Map.lookup (2) fields)
   }
 to_Struct _ = error "not a struct"
+-- | Read a 'Struct' struct with the given 'Thrift.Protocol'
 read_Struct :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Struct
 read_Struct iprot = to_Struct <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Struct)
+-- | Deserialize a 'Struct' in pure code
 decode_Struct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Struct
 decode_Struct iprot bs = to_Struct $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Struct) bs
+-- | 'TypeMap' for the 'Struct' struct
 typemap_Struct :: Types.TypeMap
 typemap_Struct = Map.fromList [("first",(1,(Types.T_STRUCT Module0_Types.typemap_Struct))),("second",(2,(Types.T_STRUCT Module1_Types.typemap_Struct)))]
+-- | Default values for the 'Struct' struct
 default_Struct :: Struct
 default_Struct = Struct{
   struct_first = Module0_Types.default_Struct,
   struct_second = Module1_Types.default_Struct}
+-- | Definition of the BigStruct struct
 data BigStruct = BigStruct
   { bigStruct_s :: Module2_Types.Struct
+    -- ^ s field of the BigStruct struct
   , bigStruct_id :: Int.Int32
+    -- ^ id field of the BigStruct struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable BigStruct where
   encode = encode_BigStruct
@@ -120,27 +134,35 @@ instance Arbitrary.Arbitrary BigStruct where
     [ if obj == default_BigStruct{bigStruct_s = bigStruct_s obj} then Nothing else Just $ default_BigStruct{bigStruct_s = bigStruct_s obj}
     , if obj == default_BigStruct{bigStruct_id = bigStruct_id obj} then Nothing else Just $ default_BigStruct{bigStruct_id = bigStruct_id obj}
     ]
+-- | Translate a 'BigStruct' to a 'Types.ThriftVal'
 from_BigStruct :: BigStruct -> Types.ThriftVal
 from_BigStruct record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v11 -> Just (1, ("s",Module2_Types.from_Struct _v11))) $ bigStruct_s record
   , (\_v11 -> Just (2, ("id",Types.TI32 _v11))) $ bigStruct_id record
   ]
+-- | Write a 'BigStruct' with the given 'Thrift.Protocol'
 write_BigStruct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BigStruct -> IO ()
 write_BigStruct oprot record = Thrift.writeVal oprot $ from_BigStruct record
+-- | Serialize a 'BigStruct' in pure code
 encode_BigStruct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BigStruct -> BS.ByteString
 encode_BigStruct oprot record = Thrift.serializeVal oprot $ from_BigStruct record
+-- | Translate a 'Types.ThriftVal' to a 'BigStruct'
 to_BigStruct :: Types.ThriftVal -> BigStruct
 to_BigStruct (Types.TStruct fields) = BigStruct{
   bigStruct_s = maybe (bigStruct_s default_BigStruct) (\(_,_val13) -> (case _val13 of {Types.TStruct _val14 -> (Module2_Types.to_Struct (Types.TStruct _val14)); _ -> error "wrong type"})) (Map.lookup (1) fields),
   bigStruct_id = maybe (bigStruct_id default_BigStruct) (\(_,_val13) -> (case _val13 of {Types.TI32 _val15 -> _val15; _ -> error "wrong type"})) (Map.lookup (2) fields)
   }
 to_BigStruct _ = error "not a struct"
+-- | Read a 'BigStruct' struct with the given 'Thrift.Protocol'
 read_BigStruct :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO BigStruct
 read_BigStruct iprot = to_BigStruct <$> Thrift.readVal iprot (Types.T_STRUCT typemap_BigStruct)
+-- | Deserialize a 'BigStruct' in pure code
 decode_BigStruct :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> BigStruct
 decode_BigStruct iprot bs = to_BigStruct $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_BigStruct) bs
+-- | 'TypeMap' for the 'BigStruct' struct
 typemap_BigStruct :: Types.TypeMap
 typemap_BigStruct = Map.fromList [("s",(1,(Types.T_STRUCT Module2_Types.typemap_Struct))),("id",(2,Types.T_I32))]
+-- | Default values for the 'BigStruct' struct
 default_BigStruct :: BigStruct
 default_BigStruct = BigStruct{
   bigStruct_s = Module2_Types.default_Struct,

--- a/thrift/compiler/test/fixtures/service-fuzzer/gen-hs/TestService.hs
+++ b/thrift/compiler/test/fixtures/service-fuzzer/gen-hs/TestService.hs
@@ -52,23 +52,40 @@ import qualified Module_Types
 import qualified TestService_Iface as Iface
 -- HELPER FUNCTIONS AND STRUCTURES --
 
+-- | Definition of the Init_args struct
 data Init_args = Init_args
   { init_args_int1 :: Int.Int64
+    -- ^ int1 field of the Init_args struct
   , init_args_int2 :: Int.Int64
+    -- ^ int2 field of the Init_args struct
   , init_args_int3 :: Int.Int64
+    -- ^ int3 field of the Init_args struct
   , init_args_int4 :: Int.Int64
+    -- ^ int4 field of the Init_args struct
   , init_args_int5 :: Int.Int64
+    -- ^ int5 field of the Init_args struct
   , init_args_int6 :: Int.Int64
+    -- ^ int6 field of the Init_args struct
   , init_args_int7 :: Int.Int64
+    -- ^ int7 field of the Init_args struct
   , init_args_int8 :: Int.Int64
+    -- ^ int8 field of the Init_args struct
   , init_args_int9 :: Int.Int64
+    -- ^ int9 field of the Init_args struct
   , init_args_int10 :: Int.Int64
+    -- ^ int10 field of the Init_args struct
   , init_args_int11 :: Int.Int64
+    -- ^ int11 field of the Init_args struct
   , init_args_int12 :: Int.Int64
+    -- ^ int12 field of the Init_args struct
   , init_args_int13 :: Int.Int64
+    -- ^ int13 field of the Init_args struct
   , init_args_int14 :: Int.Int64
+    -- ^ int14 field of the Init_args struct
   , init_args_int15 :: Int.Int64
+    -- ^ int15 field of the Init_args struct
   , init_args_int16 :: Int.Int64
+    -- ^ int16 field of the Init_args struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Init_args where
   encode = encode_Init_args
@@ -130,6 +147,7 @@ instance Arbitrary.Arbitrary Init_args where
     , if obj == default_Init_args{init_args_int15 = init_args_int15 obj} then Nothing else Just $ default_Init_args{init_args_int15 = init_args_int15 obj}
     , if obj == default_Init_args{init_args_int16 = init_args_int16 obj} then Nothing else Just $ default_Init_args{init_args_int16 = init_args_int16 obj}
     ]
+-- | Translate a 'Init_args' to a 'Types.ThriftVal'
 from_Init_args :: Init_args -> Types.ThriftVal
 from_Init_args record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v3 -> Just (1, ("int1",Types.TI64 _v3))) $ init_args_int1 record
@@ -149,10 +167,13 @@ from_Init_args record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   , (\_v3 -> Just (15, ("int15",Types.TI64 _v3))) $ init_args_int15 record
   , (\_v3 -> Just (16, ("int16",Types.TI64 _v3))) $ init_args_int16 record
   ]
+-- | Write a 'Init_args' with the given 'Thrift.Protocol'
 write_Init_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Init_args -> IO ()
 write_Init_args oprot record = Thrift.writeVal oprot $ from_Init_args record
+-- | Serialize a 'Init_args' in pure code
 encode_Init_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Init_args -> BS.ByteString
 encode_Init_args oprot record = Thrift.serializeVal oprot $ from_Init_args record
+-- | Translate a 'Types.ThriftVal' to a 'Init_args'
 to_Init_args :: Types.ThriftVal -> Init_args
 to_Init_args (Types.TStruct fields) = Init_args{
   init_args_int1 = maybe (init_args_int1 default_Init_args) (\(_,_val5) -> (case _val5 of {Types.TI64 _val6 -> _val6; _ -> error "wrong type"})) (Map.lookup (1) fields),
@@ -173,12 +194,16 @@ to_Init_args (Types.TStruct fields) = Init_args{
   init_args_int16 = maybe (init_args_int16 default_Init_args) (\(_,_val5) -> (case _val5 of {Types.TI64 _val21 -> _val21; _ -> error "wrong type"})) (Map.lookup (16) fields)
   }
 to_Init_args _ = error "not a struct"
+-- | Read a 'Init_args' struct with the given 'Thrift.Protocol'
 read_Init_args :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Init_args
 read_Init_args iprot = to_Init_args <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Init_args)
+-- | Deserialize a 'Init_args' in pure code
 decode_Init_args :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Init_args
 decode_Init_args iprot bs = to_Init_args $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Init_args) bs
+-- | 'TypeMap' for the 'Init_args' struct
 typemap_Init_args :: Types.TypeMap
 typemap_Init_args = Map.fromList [("int1",(1,Types.T_I64)),("int2",(2,Types.T_I64)),("int3",(3,Types.T_I64)),("int4",(4,Types.T_I64)),("int5",(5,Types.T_I64)),("int6",(6,Types.T_I64)),("int7",(7,Types.T_I64)),("int8",(8,Types.T_I64)),("int9",(9,Types.T_I64)),("int10",(10,Types.T_I64)),("int11",(11,Types.T_I64)),("int12",(12,Types.T_I64)),("int13",(13,Types.T_I64)),("int14",(14,Types.T_I64)),("int15",(15,Types.T_I64)),("int16",(16,Types.T_I64))]
+-- | Default values for the 'Init_args' struct
 default_Init_args :: Init_args
 default_Init_args = Init_args{
   init_args_int1 = 0,
@@ -197,8 +222,10 @@ default_Init_args = Init_args{
   init_args_int14 = 0,
   init_args_int15 = 0,
   init_args_int16 = 0}
+-- | Definition of the Init_result struct
 data Init_result = Init_result
   { init_result_success :: Int.Int64
+    -- ^ success field of the Init_result struct
   } deriving (Show,Eq,Typeable.Typeable)
 instance Serializable.ThriftSerializable Init_result where
   encode = encode_Init_result
@@ -215,25 +242,33 @@ instance Arbitrary.Arbitrary Init_result where
              | otherwise = Maybe.catMaybes
     [ if obj == default_Init_result{init_result_success = init_result_success obj} then Nothing else Just $ default_Init_result{init_result_success = init_result_success obj}
     ]
+-- | Translate a 'Init_result' to a 'Types.ThriftVal'
 from_Init_result :: Init_result -> Types.ThriftVal
 from_Init_result record = Types.TStruct $ Map.fromList $ Maybe.catMaybes
   [ (\_v25 -> Just (0, ("success",Types.TI64 _v25))) $ init_result_success record
   ]
+-- | Write a 'Init_result' with the given 'Thrift.Protocol'
 write_Init_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Init_result -> IO ()
 write_Init_result oprot record = Thrift.writeVal oprot $ from_Init_result record
+-- | Serialize a 'Init_result' in pure code
 encode_Init_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> Init_result -> BS.ByteString
 encode_Init_result oprot record = Thrift.serializeVal oprot $ from_Init_result record
+-- | Translate a 'Types.ThriftVal' to a 'Init_result'
 to_Init_result :: Types.ThriftVal -> Init_result
 to_Init_result (Types.TStruct fields) = Init_result{
   init_result_success = maybe (init_result_success default_Init_result) (\(_,_val27) -> (case _val27 of {Types.TI64 _val28 -> _val28; _ -> error "wrong type"})) (Map.lookup (0) fields)
   }
 to_Init_result _ = error "not a struct"
+-- | Read a 'Init_result' struct with the given 'Thrift.Protocol'
 read_Init_result :: (Thrift.Transport t, Thrift.Protocol p) => p t -> IO Init_result
 read_Init_result iprot = to_Init_result <$> Thrift.readVal iprot (Types.T_STRUCT typemap_Init_result)
+-- | Deserialize a 'Init_result' in pure code
 decode_Init_result :: (Thrift.Protocol p, Thrift.Transport t) => p t -> BS.ByteString -> Init_result
 decode_Init_result iprot bs = to_Init_result $ Thrift.deserializeVal iprot (Types.T_STRUCT typemap_Init_result) bs
+-- | 'TypeMap' for the 'Init_result' struct
 typemap_Init_result :: Types.TypeMap
 typemap_Init_result = Map.fromList [("success",(0,Types.T_I64))]
+-- | Default values for the 'Init_result' struct
 default_Init_result :: Init_result
 default_Init_result = Init_result{
   init_result_success = 0}


### PR DESCRIPTION
Summary:
`enable_haddock` used to be a legacy way to hide TARGETS away from the haddock build if we don't want to include them in the haddock documentation. However, currently it's only in use in the Haskell Thrift Compiler to control whether the Haddock Markup should be generated for the Haskell Code or not. This is not very useful, there's no problem in adding the haddock markup to all generated modules.

Note: this only impacts Haskell Targets and the Haskell Thrift Compiler

Reviewed By: zilberstein

Differential Revision: D15923866

