### PR TITLE
Synchronize Hack files

### DIFF
--- a/thrift/lib/hack/import_from_www.php
+++ b/thrift/lib/hack/import_from_www.php
@@ -1,10 +1,24 @@
 <?hh
+/*
+ * Copyright 2019-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 class ImportThriftLibFromWWW {
   public static function run(array<string> $argv): void {
     invariant(count($argv) >= 2, 'Need to specify path to www');
     self::importHackLib($argv[1]);
-    self::transpileHack();
   }
 
   protected static function importHackLib(string $www_path): void {
@@ -52,163 +66,6 @@ class ImportThriftLibFromWWW {
         }
         file_put_contents(__DIR__.'/src/'.$path.'/'.$file, $contents);
         echo "Imported $path/$file\n";
-      }
-    );
-  }
-
-  protected static function transpileHack(): void {
-    $transpiler = realpath(__DIR__.'/../../../_bin/hphp/hack/src/h2tp/h2tp');
-    $source = realpath(__DIR__.'/src');
-    $dest = realpath(__DIR__.'/../php/src');
-
-    system('rm -rf '.$dest);
-    system($transpiler.' '.$source.' '.$dest);
-
-    file_put_contents($dest.'/Thrift.php', implode("\n", array(
-      '<?php',
-      'if (!isset($GLOBALS[\'THRIFT_ROOT\'])) {',
-      '  $GLOBALS[\'THRIFT_ROOT\'] = __DIR__;',
-      '}',
-      '',
-      '// This file was split into several separate files',
-      '// Now we can just require_once all of them',
-      '',
-      'require_once $GLOBALS[\'THRIFT_ROOT\'].\'/TType.php\';',
-      'require_once $GLOBALS[\'THRIFT_ROOT\'].\'/TMessageType.php\';',
-      'require_once $GLOBALS[\'THRIFT_ROOT\'].\'/TException.php\';',
-      'require_once $GLOBALS[\'THRIFT_ROOT\'].\'/TBase.php\';',
-      'require_once $GLOBALS[\'THRIFT_ROOT\'].\'/IThriftClient.php\';',
-      'require_once $GLOBALS[\'THRIFT_ROOT\'].\'/IThriftProcessor.php\';',
-      'require_once $GLOBALS[\'THRIFT_ROOT\'].\'/IThriftStruct.php\';',
-      'require_once $GLOBALS[\'THRIFT_ROOT\'].\'/TProcessorEventHandler.php\';',
-      'require_once $GLOBALS[\'THRIFT_ROOT\'].\'/TClientEventHandler.php\';',
-      'require_once $GLOBALS[\'THRIFT_ROOT\'].\'/TApplicationException.php\';',
-      'require_once $GLOBALS[\'THRIFT_ROOT\'].\'/protocol/TProtocol.php\';',
-      'require_once $GLOBALS[\'THRIFT_ROOT\'].\'/transport/TTransport.php\';',
-      '',
-    )));
-
-    file_put_contents($dest.'/autoload.php', implode("\n", array(
-      '<?php',
-      '// Thrift autoload support is deprecated.',
-      '// Instead, use the Composer autoloader or another',
-      '// autoloader implementation.',
-      '',
-    )));
-
-    $nonclass_files = ImmSet {
-      '/Thrift.php',
-      '/autoload.php',
-    };
-    $classes = Map {};
-
-    self::walkPHPFiles(
-      $dest,
-      array(''),
-      function (string $root, string $path, string $file) use ($classes, $nonclass_files) {
-        if (strpos($path, '__tests__') !== false) {
-          echo "Skipping $path/$file\n";
-          return;
-        }
-
-        if (!$nonclass_files->contains($path.'/'.$file)) {
-          $classes[basename($file, '.php')] = $path.'/'.$file;
-        }
-
-        $contents = file_get_contents($root.$path.'/'.$file);
-
-        $header = array(
-          '<?php',
-          '',
-          '/**',
-          '* Copyright (c) 2006- Facebook',
-          '* Distributed under the Thrift Software License',
-          '*',
-          '* See accompanying file LICENSE or visit the Thrift site at:',
-          '* http://developers.facebook.com/thrift/',
-          '*',
-          '* @package '.str_replace('/', '.', dirname('thrift'.$path.'/'.$file)),
-          '*/',
-          '',
-          '',
-        );
-
-        $contents = preg_replace('#<\?php\n#', implode("\n", $header), $contents);
-
-        file_put_contents($root.$path.'/'.$file, $contents);
-
-        echo "Added header to $path/$file\n";
-      }
-    );
-
-    self::walkPHPFiles(
-      $dest,
-      array(''),
-      function (string $root, string $path, string $file) use ($classes, $nonclass_files) {
-        if (strpos($path, '__tests__') !== false) {
-          echo "Skipping $path/$file\n";
-          return;
-        }
-
-        if ($nonclass_files->contains($path.'/'.$file)) {
-          return;
-        }
-
-        $contents = file_get_contents($root.$path.'/'.$file);
-
-        $includes = Vector {};
-        $skip_includes = ImmMap {
-          'TProtocol.php' => ImmSet {
-            'TBinaryProtocolAccelerated',
-            'TBinaryProtocolUnaccelerated',
-            'TCompactProtocolAccelerated',
-            'TCompactProtocolUnaccelerated',
-          },
-        };
-        foreach ($classes as $class => $classpath) {
-          if ($file === $class.'.php') {
-            continue;
-          }
-          if ($skip_includes->containsKey($file)) {
-            if ($skip_includes->at($file)->contains($class)) {
-              continue;
-            }
-          }
-          if (preg_match('/'.$class.'[^a-zA-Z]/', $contents)) {
-            $includes[] = $classpath;
-          }
-        }
-
-        if (!$includes->isEmpty()) {
-          sort($includes);
-          $hacklib = 'require_once ($GLOBALS["HACKLIB_ROOT"]);';
-          $thrift_root_path = '__DIR__';
-
-          $subdirs = substr_count($path, '/');
-          if ($subdirs > 0) {
-            $thrift_root_path = '__DIR__.\''.str_repeat('/..', $subdirs).'\'';
-          }
-
-          $thrift_root = implode("\n", array(
-            'if (!isset($GLOBALS[\'THRIFT_ROOT\'])) {',
-            '  $GLOBALS[\'THRIFT_ROOT\'] = '.$thrift_root_path.';',
-            '}',
-          ));
-
-          $replacement = "$hacklib\n$thrift_root\n".implode("\n", $includes->map(function ($path): string {
-            return 'require_once $GLOBALS[\'THRIFT_ROOT\'].\''.$path.'\';';
-          }));
-
-          $contents = str_replace(
-            $hacklib,
-            $replacement,
-            $contents,
-          );
-
-          file_put_contents($root.$path.'/'.$file, $contents);
-
-          echo "Added includes to $path/$file\n";
-        }
       }
     );
   }

--- a/thrift/lib/hack/src/IThriftAsyncIf.php
+++ b/thrift/lib/hack/src/IThriftAsyncIf.php
@@ -1,14 +1,19 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 interface IThriftAsyncIf extends IThriftIf {
 }

--- a/thrift/lib/hack/src/IThriftAsyncProcessor.php
+++ b/thrift/lib/hack/src/IThriftAsyncProcessor.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 interface IThriftAsyncProcessor extends IThriftProcessor {
   public function processAsync(
     TProtocol $input,

--- a/thrift/lib/hack/src/IThriftClient.php
+++ b/thrift/lib/hack/src/IThriftClient.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Base interface for Thrift clients
  */

--- a/thrift/lib/hack/src/IThriftIf.php
+++ b/thrift/lib/hack/src/IThriftIf.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Base interface for Thrift service handlers/clients
  */

--- a/thrift/lib/hack/src/IThriftProcessor.php
+++ b/thrift/lib/hack/src/IThriftProcessor.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Base interface for Thrift processors
  */

--- a/thrift/lib/hack/src/IThriftShapishStruct.php
+++ b/thrift/lib/hack/src/IThriftShapishStruct.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Interface for Thrift structs that support conversions to shapes
  */
@@ -18,8 +23,4 @@ interface IThriftShapishStruct extends IThriftStruct {
 
   public function __toShape(): this::TShape;
   public static function __fromShape(this::TShape $shape): this;
-
-  public static function __jsonArrayToShape(
-    array<arraykey, mixed> $json_data,
-  ): ?this::TShape;
 }

--- a/thrift/lib/hack/src/IThriftStruct.php
+++ b/thrift/lib/hack/src/IThriftStruct.php
@@ -1,55 +1,97 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Base interface for Thrift structs
  */
 <<__ConsistentConstruct>>
 interface IThriftStruct {
 
-  const type TFieldSpec = shape(
-    'var' => string,
-    'type' => TType,
-    ?'union' => bool,
-    ?'etype' => TType,
-    ?'elem' => this::TElemSpec,
-    ?'ktype' => TType,
-    ?'vtype' => TType,
-    ?'key' => this::TElemSpec,
-    ?'val' => this::TElemSpec,
-    ?'format' => string,
-    ?'class' => string,
-    ?'enum' => string,
-  );
-  const type TElemSpec = shape(
-    'type' => TType,
-    ?'etype' => TType,
-    ?'elem' => mixed, // this::TElemSpec once hack supports recursive types
-    ?'ktype' => TType,
-    ?'vtype' => TType,
-    ?'key' => mixed, // this::TElemSpec once hack supports recursive types
-    ?'val' => mixed, // this::TElemSpec once hack supports recursive types
-    ?'format' => string,
-    ?'class' => string,
-    ?'enum' => string,
-  );
+  const type TFieldSpec = ThriftStructFieldSpecImpl;
+  // Union of TFieldSpec and TElemSpec. For use in places that operate on both.
+  const type TGenericSpec = ThriftStructGenericSpecImpl;
+  const type TSpec = KeyedContainer<int, this::TFieldSpec>;
+  const type TFieldMap = KeyedContainer<string, int>;
 
-  abstract const dict<int, this::TFieldSpec> SPEC;
-  abstract const dict<string, int> FIELDMAP;
+  abstract const this::TSpec SPEC;
+  abstract const this::TFieldMap FIELDMAP;
   abstract const int STRUCTURAL_ID;
 
   <<__Rx>>
   public function __construct();
   public function getName(): string;
-  public function read(TProtocol $input): int;
+  <<__Rx, __AtMostRxAsArgs, __Mutable>>
+  public function read(
+    <<__OnlyRxIfImpl(IRxTProtocol::class), __Mutable>>
+    TProtocol $input,
+  ): int;
   public function write(TProtocol $input): int;
 }
+
+type ThriftStructFieldSpecImpl = shape(
+  'var' => string,
+  'type' => TType,
+  ?'union' => bool,
+  ?'etype' => TType,
+  ?'elem' => ThriftStructElemSpecImpl,
+  ?'ktype' => TType,
+  ?'vtype' => TType,
+  ?'key' => ThriftStructElemSpecImpl,
+  ?'val' => ThriftStructElemSpecImpl,
+  ?'format' => string,
+  ?'class' => classname<IThriftStruct>,
+  ?'enum' => string, // classname<HH\BuiltinEnum<int>>
+);
+type ThriftStructElemSpecRecursiveImpl<
+  T as ThriftStructElemSpecRecursiveImpl<T>,
+> = shape(
+  'type' => TType,
+  ?'etype' => TType,
+  ?'elem' => T,
+  ?'ktype' => TType,
+  ?'vtype' => TType,
+  ?'key' => T,
+  ?'val' => T,
+  ?'format' => string,
+  ?'class' => classname<IThriftStruct>,
+  ?'enum' => string, // classname<HH\BuiltinEnum<int>>
+);
+type ThriftStructGenericSpecRecursiveImpl<
+  T as ThriftStructGenericSpecRecursiveImpl<T>,
+> = shape(
+  ?'var' => string,
+  ?'type' => TType,
+  ?'union' => bool,
+  ?'etype' => TType,
+  ?'elem' => T,
+  ?'ktype' => TType,
+  ?'vtype' => TType,
+  ?'key' => T,
+  ?'val' => T,
+  ?'format' => string,
+  ?'class' => classname<IThriftStruct>,
+  ?'enum' => string, // classname<HH\BuiltinEnum<int>>
+  ...
+);
+type ThriftStructElemSpecImpl = ThriftStructElemSpecRecursiveImpl<
+  /* HH_FIXME[4101] */ /* HH_FIXME[4102] */
+  ThriftStructElemSpecRecursiveImpl,
+>;
+type ThriftStructGenericSpecImpl = ThriftStructGenericSpecRecursiveImpl<
+  /* HH_FIXME[4101] */ /* HH_FIXME[4102] */
+  ThriftStructGenericSpecRecursiveImpl
+>;

--- a/thrift/lib/hack/src/IThriftSyncIf.php
+++ b/thrift/lib/hack/src/IThriftSyncIf.php
@@ -1,14 +1,19 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 interface IThriftSyncIf extends IThriftIf {
 }

--- a/thrift/lib/hack/src/IThriftUnion.php
+++ b/thrift/lib/hack/src/IThriftUnion.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Base interface for Thrift unions
  */

--- a/thrift/lib/hack/src/TApplicationException.php
+++ b/thrift/lib/hack/src/TApplicationException.php
@@ -1,21 +1,40 @@
 <?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+final class TApplicationException extends TException
+  implements IThriftStruct {
 
-class TApplicationException extends TException {
-  static array<int, array<string, mixed>>
-    $_TSPEC = array(
-      1 => array('var' => 'message', 'type' => TType::STRING),
-      2 => array('var' => 'code', 'type' => TType::I32),
-    );
+  use ThriftSerializationTrait;
+
+  const dict<int, this::TFieldSpec> SPEC = dict[
+    1 => shape(
+      'var' => 'message',
+      'type' => TType::STRING,
+    ),
+    2 => shape(
+      'var' => 'code',
+      'type' => TType::I32,
+    ),
+  ];
+  const dict<string, int> FIELDMAP = dict[
+    'message' => 1,
+    'code' => 2,
+  ];
+  const int STRUCTURAL_ID = 0;
 
   const UNKNOWN = 0;
   const UNKNOWN_METHOD = 1;
@@ -25,29 +44,12 @@ class TApplicationException extends TException {
   const MISSING_RESULT = 5;
   const INVALID_TRANSFORM = 6;
 
+  <<__Rx>>
   public function __construct(?string $message = null, int $code = 0) {
     parent::__construct($message, $code);
   }
 
-  public function read(TProtocol $output) {
-    return $this->_read('TApplicationException', self::$_TSPEC, $output);
-  }
-
-  public function write(TProtocol $output): int {
-    $xfer = 0;
-    $xfer += $output->writeStructBegin('TApplicationException');
-    if ($message = $this->getMessage()) {
-      $xfer += $output->writeFieldBegin('message', TType::STRING, 1);
-      $xfer += $output->writeString($message);
-      $xfer += $output->writeFieldEnd();
-    }
-    if ($code = $this->getCode()) {
-      $xfer += $output->writeFieldBegin('type', TType::I32, 2);
-      $xfer += $output->writeI32($code);
-      $xfer += $output->writeFieldEnd();
-    }
-    $xfer += $output->writeFieldStop();
-    $xfer += $output->writeStructEnd();
-    return $xfer;
+  public function getName(): string {
+    return 'TApplicationException';
   }
 }

--- a/thrift/lib/hack/src/TClientAsyncHandler.php
+++ b/thrift/lib/hack/src/TClientAsyncHandler.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * This allows clients to perform calls as generators
  */

--- a/thrift/lib/hack/src/TClientEventHandler.php
+++ b/thrift/lib/hack/src/TClientEventHandler.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Event handler for thrift clients
  */

--- a/thrift/lib/hack/src/TClientMultiEventHandler.php
+++ b/thrift/lib/hack/src/TClientMultiEventHandler.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 final class TClientMultiEventHandler extends TClientEventHandler {
   private Map<string, TClientEventHandler> $handlers;
 
@@ -32,6 +37,11 @@ final class TClientMultiEventHandler extends TClientEventHandler {
     return $handler;
   }
 
+  public function getHandlers(): ConstMap<string, TClientEventHandler> {
+    return new ImmMap($this->handlers);
+  }
+
+  <<__Override>>
   public function preSend(
     string $fn_name,
     mixed $args,
@@ -42,6 +52,7 @@ final class TClientMultiEventHandler extends TClientEventHandler {
     }
   }
 
+  <<__Override>>
   public function postSend(
     string $fn_name,
     mixed $args,
@@ -52,6 +63,7 @@ final class TClientMultiEventHandler extends TClientEventHandler {
     }
   }
 
+  <<__Override>>
   public function sendError(
     string $fn_name,
     mixed $args,
@@ -63,12 +75,14 @@ final class TClientMultiEventHandler extends TClientEventHandler {
     }
   }
 
+  <<__Override>>
   public function preRecv(string $fn_name, ?int $ex_sequence_id): void {
     foreach ($this->handlers as $handler) {
       $handler->preRecv($fn_name, $ex_sequence_id);
     }
   }
 
+  <<__Override>>
   public function postRecv(
     string $fn_name,
     ?int $ex_sequence_id,
@@ -79,6 +93,7 @@ final class TClientMultiEventHandler extends TClientEventHandler {
     }
   }
 
+  <<__Override>>
   public function recvException(
     string $fn_name,
     ?int $ex_sequence_id,
@@ -89,6 +104,7 @@ final class TClientMultiEventHandler extends TClientEventHandler {
     }
   }
 
+  <<__Override>>
   public function recvError(
     string $fn_name,
     ?int $ex_sequence_id,

--- a/thrift/lib/hack/src/TException.php
+++ b/thrift/lib/hack/src/TException.php
@@ -1,22 +1,21 @@
-<?hh
+<?hh // partial
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
-/**
- * NOTE(mcslee): This currently contains a ton of duplicated code from TBase
- * because we need to save CPU cycles and this is not yet in an extension.
- * Ideally we'd multiply-inherit TException from both Exception and Base, but
- * that's not possible in PHP and there are no modules either, so for now we
- * apologetically take a trip to HackTown.
+/*
+ * Copyright 2006-present Facebook, Inc.
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Can be called with standard Exception constructor (message, code) or with
  * Thrift Base object constructor (spec, vals).
  *
@@ -24,6 +23,11 @@
  * @param mixed $p2 Code (integer) or values (array)
  */
 class TException extends Exception {
+
+  public string $message = '';
+  public int $code = 0;
+
+  <<__Rx>>
   public function __construct($p1 = null, $p2 = 0) {
     if (is_array($p1) && is_array($p2)) {
       $spec = $p1;
@@ -31,341 +35,14 @@ class TException extends Exception {
       foreach ($spec as $fid => $fspec) {
         $var = $fspec['var'];
         if (isset($vals[$var])) {
+          /* HH_FIXME[2011] dynamic method is allowed on non dynamic types */
           $this->$var = $vals[$var];
         }
       }
       parent::__construct();
     } else {
+      /* HH_FIXME[4281] error revealed by improved type refinements */
       parent::__construct((string) $p1, $p2);
     }
   }
-
-  static
-    $tmethod = array(
-      TType::BOOL => 'Bool',
-      TType::BYTE => 'Byte',
-      TType::I16 => 'I16',
-      TType::I32 => 'I32',
-      TType::I64 => 'I64',
-      TType::DOUBLE => 'Double',
-      TType::STRING => 'String',
-      TType::FLOAT => 'Float',
-    );
-
-  private function _readMap(&$var, $spec, $input) {
-    $xfer = 0;
-    $ktype = $spec['ktype'];
-    $vtype = $spec['vtype'];
-    $kread = $vread = null;
-    $kspec = array();
-    $vspec = array();
-    if (isset(TBase::$tmethod[$ktype])) {
-      $kread = 'read'.TBase::$tmethod[$ktype];
-    } else {
-      $kspec = $spec['key'];
-    }
-    if (isset(TBase::$tmethod[$vtype])) {
-      $vread = 'read'.TBase::$tmethod[$vtype];
-    } else {
-      $vspec = $spec['val'];
-    }
-    $var = array();
-    $_ktype = 0;
-    $_vtype = 0;
-    $size = 0;
-    $xfer += $input->readMapBegin(inout $_ktype, inout $_vtype, inout $size);
-    for ($i = 0; $i < $size; ++$i) {
-      $key = $val = null;
-      if ($kread !== null) {
-        $xfer += $input->$kread($key);
-      } else {
-        switch ($ktype) {
-          case TType::STRUCT:
-            $class = $kspec['class'];
-            $key = new $class();
-            $xfer += $key->read($input);
-            break;
-          case TType::MAP:
-            $xfer += $this->_readMap($key, $kspec, $input);
-            break;
-          case TType::LST:
-            $xfer += $this->_readList($key, $kspec, $input, false);
-            break;
-          case TType::SET:
-            $xfer += $this->_readList($key, $kspec, $input, true);
-            break;
-        }
-      }
-      if ($vread !== null) {
-        $xfer += $input->$vread($val);
-      } else {
-        switch ($vtype) {
-          case TType::STRUCT:
-            $class = $vspec['class'];
-            $val = new $class();
-            $xfer += $val->read($input);
-            break;
-          case TType::MAP:
-            $xfer += $this->_readMap($val, $vspec, $input);
-            break;
-          case TType::LST:
-            $xfer += $this->_readList($val, $vspec, $input, false);
-            break;
-          case TType::SET:
-            $xfer += $this->_readList($val, $vspec, $input, true);
-            break;
-        }
-      }
-      $var[$key] = $val;
-    }
-    $xfer += $input->readMapEnd();
-    return $xfer;
-  }
-
-  private function _readList(&$var, $spec, $input, $set = false) {
-    $xfer = 0;
-    $etype = $spec['etype'];
-    $eread = $vread = null;
-    if (isset(TBase::$tmethod[$etype])) {
-      $eread = 'read'.TBase::$tmethod[$etype];
-    } else {
-      $espec = $spec['elem'];
-    }
-    /* UNSAFE_EXPR - this array is used both as vector and a map */
-    $var = array();
-    $_etype = $size = 0;
-    if ($set) {
-      $xfer += $input->readSetBegin($_etype, $size);
-    } else {
-      $xfer += $input->readListBegin($_etype, $size);
-    }
-    for ($i = 0; $i < $size; ++$i) {
-      $elem = null;
-      if ($eread !== null) {
-        $xfer += $input->$eread($elem);
-      } else {
-        $espec = $spec['elem'];
-        switch ($etype) {
-          case TType::STRUCT:
-            $class = $espec['class'];
-            $elem = new $class();
-            $xfer += $elem->read($input);
-            break;
-          case TType::MAP:
-            $xfer += $this->_readMap($elem, $espec, $input);
-            break;
-          case TType::LST:
-            $xfer += $this->_readList($elem, $espec, $input, false);
-            break;
-          case TType::SET:
-            $xfer += $this->_readList($elem, $espec, $input, true);
-            break;
-        }
-      }
-      if ($set) {
-        $var[$elem] = true;
-      } else {
-        $var[] = $elem;
-      }
-    }
-    if ($set) {
-      $xfer += $input->readSetEnd();
-    } else {
-      $xfer += $input->readListEnd();
-    }
-    return $xfer;
-  }
-
-  protected function _read($class, $spec, $input) {
-    $xfer = 0;
-    $fname = null;
-    $ftype = 0;
-    $fid = 0;
-    $xfer += $input->readStructBegin(inout $fname);
-    while (true) {
-      $xfer += $input->readFieldBegin(inout $fname, inout $ftype, inout $fid);
-      if ($ftype == TType::STOP) {
-        break;
-      }
-      if (isset($spec[$fid])) {
-        $fspec = $spec[$fid];
-        $var = $fspec['var'];
-        if ($ftype == $fspec['type']) {
-          $xfer = 0;
-          if (isset(TBase::$tmethod[$ftype])) {
-            $func = 'read'.TBase::$tmethod[$ftype];
-            $xfer += $input->$func($this->$var);
-          } else {
-            switch ($ftype) {
-              case TType::STRUCT:
-                $class = $fspec['class'];
-                $this->$var = new $class();
-                $xfer += $this->$var->read($input);
-                break;
-              case TType::MAP:
-                $xfer += $this->_readMap($this->$var, $fspec, $input);
-                break;
-              case TType::LST:
-                $xfer +=
-                  $this->_readList($this->$var, $fspec, $input, false);
-                break;
-              case TType::SET:
-                $xfer +=
-                  $this->_readList($this->$var, $fspec, $input, true);
-                break;
-            }
-          }
-        } else {
-          $xfer += $input->skip($ftype);
-        }
-      } else {
-        $xfer += $input->skip($ftype);
-      }
-      $xfer += $input->readFieldEnd();
-    }
-    $xfer += $input->readStructEnd();
-    return $xfer;
-  }
-
-  private function _writeMap($var, $spec, $output) {
-    $xfer = 0;
-    $ktype = $spec['ktype'];
-    $vtype = $spec['vtype'];
-    $kwrite = $vwrite = null;
-    $kspec = null;
-    $vspec = null;
-    if (isset(TBase::$tmethod[$ktype])) {
-      $kwrite = 'write'.TBase::$tmethod[$ktype];
-    } else {
-      $kspec = $spec['key'];
-    }
-    if (isset(TBase::$tmethod[$vtype])) {
-      $vwrite = 'write'.TBase::$tmethod[$vtype];
-    } else {
-      $vspec = $spec['val'];
-    }
-    $xfer += $output->writeMapBegin($ktype, $vtype, count($var));
-    foreach ($var as $key => $val) {
-      if (isset($kwrite)) {
-        $xfer += $output->$kwrite($key);
-      } else {
-        switch ($ktype) {
-          case TType::STRUCT:
-            $xfer += $key->write($output);
-            break;
-          case TType::MAP:
-            $xfer += $this->_writeMap($key, $kspec, $output);
-            break;
-          case TType::LST:
-            $xfer += $this->_writeList($key, $kspec, $output, false);
-            break;
-          case TType::SET:
-            $xfer += $this->_writeList($key, $kspec, $output, true);
-            break;
-        }
-      }
-      if (isset($vwrite)) {
-        $xfer += $output->$vwrite($val);
-      } else {
-        switch ($vtype) {
-          case TType::STRUCT:
-            $xfer += $val->write($output);
-            break;
-          case TType::MAP:
-            $xfer += $this->_writeMap($val, $vspec, $output);
-            break;
-          case TType::LST:
-            $xfer += $this->_writeList($val, $vspec, $output, false);
-            break;
-          case TType::SET:
-            $xfer += $this->_writeList($val, $vspec, $output, true);
-            break;
-        }
-      }
-    }
-    $xfer += $output->writeMapEnd();
-    return $xfer;
-  }
-
-  private function _writeList($var, $spec, $output, $set = false) {
-    $xfer = 0;
-    $etype = $spec['etype'];
-    $ewrite = null;
-    $espec = null;
-    if (isset(TBase::$tmethod[$etype])) {
-      $ewrite = 'write'.TBase::$tmethod[$etype];
-    } else {
-      $espec = $spec['elem'];
-    }
-    if ($set) {
-      $xfer += $output->writeSetBegin($etype, count($var));
-    } else {
-      $xfer += $output->writeListBegin($etype, count($var));
-    }
-    foreach ($var as $key => $val) {
-      $elem = $set ? $key : $val;
-      if (isset($ewrite)) {
-        $xfer += $output->$ewrite($elem);
-      } else {
-        switch ($etype) {
-          case TType::STRUCT:
-            $xfer += $elem->write($output);
-            break;
-          case TType::MAP:
-            $xfer += $this->_writeMap($elem, $espec, $output);
-            break;
-          case TType::LST:
-            $xfer += $this->_writeList($elem, $espec, $output, false);
-            break;
-          case TType::SET:
-            $xfer += $this->_writeList($elem, $espec, $output, true);
-            break;
-        }
-      }
-    }
-    if ($set) {
-      $xfer += $output->writeSetEnd();
-    } else {
-      $xfer += $output->writeListEnd();
-    }
-    return $xfer;
-  }
-
-  protected function _write($class, $spec, $output) {
-    $xfer = 0;
-    $xfer += $output->writeStructBegin($class);
-    foreach ($spec as $fid => $fspec) {
-      $var = $fspec['var'];
-      if ($this->$var !== null) {
-        $ftype = $fspec['type'];
-        $xfer += $output->writeFieldBegin($var, $ftype, $fid);
-        if (isset(TBase::$tmethod[$ftype])) {
-          $func = 'write'.TBase::$tmethod[$ftype];
-          $xfer += $output->$func($this->$var);
-        } else {
-          switch ($ftype) {
-            case TType::STRUCT:
-              $xfer += $this->$var->write($output);
-              break;
-            case TType::MAP:
-              $xfer += $this->_writeMap($this->$var, $fspec, $output);
-              break;
-            case TType::LST:
-              $xfer +=
-                $this->_writeList($this->$var, $fspec, $output, false);
-              break;
-            case TType::SET:
-              $xfer +=
-                $this->_writeList($this->$var, $fspec, $output, true);
-              break;
-          }
-        }
-        $xfer += $output->writeFieldEnd();
-      }
-    }
-    $xfer += $output->writeFieldStop();
-    $xfer += $output->writeStructEnd();
-    return $xfer;
-  }
-
 }

--- a/thrift/lib/hack/src/THandlerShortCircuitException.php
+++ b/thrift/lib/hack/src/THandlerShortCircuitException.php
@@ -1,16 +1,21 @@
-<?hh
+<?hh // partial
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
-class THandlerShortCircuitException extends Exception {
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+final class THandlerShortCircuitException extends Exception {
   const int R_SUCCESS = 0;
   const int R_EXPECTED_EX = 1;
   const int R_UNEXPECTED_EX = 2;

--- a/thrift/lib/hack/src/TMessageType.php
+++ b/thrift/lib/hack/src/TMessageType.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Message types for RPC
  */

--- a/thrift/lib/hack/src/TProcessorEventHandler.php
+++ b/thrift/lib/hack/src/TProcessorEventHandler.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Event handler for thrift processors
  */

--- a/thrift/lib/hack/src/TProcessorMultiEventHandler.php
+++ b/thrift/lib/hack/src/TProcessorMultiEventHandler.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 final class TProcessorMultiEventHandler extends TProcessorEventHandler {
   private Map<string, TProcessorEventHandler> $handlers;
 
@@ -36,6 +41,7 @@ final class TProcessorMultiEventHandler extends TProcessorEventHandler {
   }
 
   // Called at the start of processing a handler method
+  <<__Override>>
   public function getHandlerContext(string $fn_name): mixed {
     $context = Map {};
     foreach ($this->handlers as $key => $handler) {
@@ -46,87 +52,101 @@ final class TProcessorMultiEventHandler extends TProcessorEventHandler {
   }
 
   // Called before the handler method's argument are read
+  <<__Override>>
   public function preRead(
     mixed $handler_context,
     string $fn_name,
     mixed $args,
   ): void {
-    invariant($handler_context instanceof Map, 'Context is not a Map');
+    invariant($handler_context is Map<_, _>, 'Context is not a Map');
     foreach ($this->handlers as $key => $handler) {
+      /* HH_FIXME[4110]: Type error revealed by type-safe instanceof feature. See https://fburl.com/instanceof */
       $handler->preRead($handler_context->at($key), $fn_name, $args);
     }
   }
 
   // Called after the handler method's argument are read
+  <<__Override>>
   public function postRead(
     mixed $handler_context,
     string $fn_name,
     mixed $args,
   ): void {
-    invariant($handler_context instanceof Map, 'Context is not a Map');
+    invariant($handler_context is Map<_, _>, 'Context is not a Map');
     foreach ($this->handlers as $key => $handler) {
+      /* HH_FIXME[4110]: Type error revealed by type-safe instanceof feature. See https://fburl.com/instanceof */
       $handler->postRead($handler_context->at($key), $fn_name, $args);
     }
   }
 
   // Called right before the handler is executed.
   // Exceptions thrown here are caught by handlerException and handlerError.
+  <<__Override>>
   public function preExec(
     mixed $handler_context,
     string $fn_name,
     mixed $args,
   ): void {
-    invariant($handler_context instanceof Map, 'Context is not a Map');
-    foreach ($this->handlers as $key => $handler) {
+    invariant($handler_context is Map<_, _>, 'Context is not a Map');
+    foreach (PHPism_FIXME::coerceKeyedTraversableOrObject($this->handlers) as $key => $handler) {
+      /* HH_FIXME[4110] Exposed by adding return type to PHPism_FIXME::coerce(Keyed)?TraversableOrObject */
       $handler->preExec($handler_context->at($key), $fn_name, $args);
     }
   }
 
   // Called right after the handler is executed.
   // Exceptions thrown here are caught by handlerException and handlerError.
+  <<__Override>>
   public function postExec(
     mixed $handler_context,
     string $fn_name,
     mixed $result,
   ): void {
-    invariant($handler_context instanceof Map, 'Context is not a Map');
+    invariant($handler_context is Map<_, _>, 'Context is not a Map');
     foreach ($this->handlers as $key => $handler) {
+      /* HH_FIXME[4110]: Type error revealed by type-safe instanceof feature. See https://fburl.com/instanceof */
       $handler->postExec($handler_context->at($key), $fn_name, $result);
     }
   }
 
   // Called before the handler method's $results are written
+  <<__Override>>
   public function preWrite(
     mixed $handler_context,
     string $fn_name,
     mixed $result,
   ): void {
-    invariant($handler_context instanceof Map, 'Context is not a Map');
+    invariant($handler_context is Map<_, _>, 'Context is not a Map');
     foreach ($this->handlers as $key => $handler) {
+      /* HH_FIXME[4110]: Type error revealed by type-safe instanceof feature. See https://fburl.com/instanceof */
       $handler->preWrite($handler_context->at($key), $fn_name, $result);
     }
   }
 
   // Called after the handler method's $results are written
+  <<__Override>>
   public function postWrite(
     mixed $handler_context,
     string $fn_name,
     mixed $result,
   ): void {
-    invariant($handler_context instanceof Map, 'Context is not a Map');
+    invariant($handler_context is Map<_, _>, 'Context is not a Map');
     foreach ($this->handlers as $key => $handler) {
+      /* HH_FIXME[4110]: Type error revealed by type-safe instanceof feature. See https://fburl.com/instanceof */
       $handler->postWrite($handler_context->at($key), $fn_name, $result);
     }
   }
 
   // Called if (and only if) the handler threw an expected $exception.
+  <<__Override>>
   public function handlerException(
     mixed $handler_context,
     string $fn_name,
     Exception $ex,
   ): void {
-    invariant($handler_context instanceof Map, 'Context is not a Map');
+    invariant($handler_context is Map<_, _>, 'Context is not a Map');
     foreach ($this->handlers as $key => $handler) {
+      /* HH_FIXME[4110]: Type error revealed by type-safe instanceof feature. See https://fburl.com/instanceof */
       $handler->handlerException($handler_context->at($key), $fn_name, $ex);
     }
   }
@@ -137,13 +157,15 @@ final class TProcessorMultiEventHandler extends TProcessorEventHandler {
    * Note that this method is NOT called if the handler threw an
    * exception that is declared in the thrift service specification
    */
+  <<__Override>>
   public function handlerError(
     mixed $handler_context,
     string $fn_name,
     Exception $ex,
   ): void {
-    invariant($handler_context instanceof Map, 'Context is not a Map');
+    invariant($handler_context is Map<_, _>, 'Context is not a Map');
     foreach ($this->handlers as $key => $handler) {
+      /* HH_FIXME[4110]: Type error revealed by type-safe instanceof feature. See https://fburl.com/instanceof */
       $handler->handlerError($handler_context->at($key), $fn_name, $ex);
     }
   }

--- a/thrift/lib/hack/src/TType.php
+++ b/thrift/lib/hack/src/TType.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Data types that can be sent via Thrift
  */

--- a/thrift/lib/hack/src/ThriftAsyncProcessor.php
+++ b/thrift/lib/hack/src/ThriftAsyncProcessor.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 abstract class ThriftAsyncProcessor extends ThriftProcessorBase
   implements IThriftAsyncProcessor {
 
@@ -24,13 +29,14 @@ abstract class ThriftAsyncProcessor extends ThriftProcessorBase
     $mtype = 0;
 
     $input->readMessageBegin(inout $fname, inout $mtype, inout $rseqid);
+    RelativeScript::setMinorPath($fname);
     $methodname = 'process_'.$fname;
-    if (!method_exists($this, $methodname)) {
+    if (!PHP\method_exists($this, $methodname)) {
       $handler_ctx = $this->eventHandler_->getHandlerContext($fname);
-      $this->eventHandler_->preRead($handler_ctx, $fname, array());
+      $this->eventHandler_->preRead($handler_ctx, $fname, darray[]);
       $input->skip(TType::STRUCT);
       $input->readMessageEnd();
-      $this->eventHandler_->postRead($handler_ctx, $fname, array());
+      $this->eventHandler_->postRead($handler_ctx, $fname, darray[]);
       $x = new TApplicationException(
         'Function '.$fname.' not implemented.',
         TApplicationException::UNKNOWN_METHOD,
@@ -42,12 +48,12 @@ abstract class ThriftAsyncProcessor extends ThriftProcessorBase
       $output->getTransport()->flush();
       return true;
     }
-    /* UNSAFE_EXPR[2011]: This is safe */
+    /* HH_FIXME[2011]: This is safe */
     await $this->$methodname($rseqid, $input, $output);
     return true;
   }
 
-  final public function process(TProtocol $input, TProtocol $output): bool {
-    return HH\Asio\join($this->processAsync($input, $output)->getWaitHandle());
+  public function process(TProtocol $input, TProtocol $output): bool {
+    return Asio::awaitSynchronously($this->processAsync($input, $output));
   }
 }

--- a/thrift/lib/hack/src/ThriftClientBase.php
+++ b/thrift/lib/hack/src/ThriftClientBase.php
@@ -1,14 +1,21 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+type ThriftClientFactory<T> = (string, (function (TProtocol, ?TProtocol): T));
 
 <<__ConsistentConstruct>>
 abstract class ThriftClientBase implements IThriftClient {
@@ -22,7 +29,7 @@ abstract class ThriftClientBase implements IThriftClient {
   final public static function factory(
   ): (string, (function (TProtocol, ?TProtocol): this)) {
     return tuple(
-      get_called_class(),
+      static::class,
       function(TProtocol $input, ?TProtocol $output) {
         return new static($input, $output);
       },

--- a/thrift/lib/hack/src/ThriftProcessorBase.php
+++ b/thrift/lib/hack/src/ThriftProcessorBase.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 abstract class ThriftProcessorBase implements IThriftProcessor {
   abstract const type TThriftIf as IThriftIf;
   protected TProcessorEventHandler $eventHandler_;

--- a/thrift/lib/hack/src/ThriftSyncProcessor.php
+++ b/thrift/lib/hack/src/ThriftSyncProcessor.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 abstract class ThriftSyncProcessor
   extends ThriftProcessorBase {
 
@@ -21,13 +26,14 @@ abstract class ThriftSyncProcessor
     $mtype = 0;
 
     $input->readMessageBegin(inout $fname, inout $mtype, inout $rseqid);
+    RelativeScript::setMinorPath($fname);
     $methodname = 'process_'.$fname;
-    if (!method_exists($this, $methodname)) {
+    if (!PHP\method_exists($this, $methodname)) {
       $handler_ctx = $this->eventHandler_->getHandlerContext($fname);
-      $this->eventHandler_->preRead($handler_ctx, $fname, array());
+      $this->eventHandler_->preRead($handler_ctx, $fname, darray[]);
       $input->skip(TType::STRUCT);
       $input->readMessageEnd();
-      $this->eventHandler_->postRead($handler_ctx, $fname, array());
+      $this->eventHandler_->postRead($handler_ctx, $fname, darray[]);
       $x = new TApplicationException(
         'Function '.$fname.' not implemented.',
         TApplicationException::UNKNOWN_METHOD,
@@ -39,7 +45,8 @@ abstract class ThriftSyncProcessor
       $output->getTransport()->flush();
       return true;
     }
-    /* UNSAFE_EXPR[2011]: This is safe */
+
+    /* HH_FIXME[2011] Previously hidden by unsafe_expr */
     $this->$methodname($rseqid, $input, $output);
     return true;
   }

--- a/thrift/lib/hack/src/ThriftUtil.php
+++ b/thrift/lib/hack/src/ThriftUtil.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 abstract final class ThriftUtil {
 
   public static function mapDict<Tk as arraykey, Tv1, Tv2>(
@@ -47,6 +52,7 @@ abstract final class ThriftUtil {
 
   public static function toDArray<Tk, Tv>(
     KeyedTraversable<Tk, Tv> $traversable,
+  /* HH_FIXME[4319] Revealed by enforcing darray type declarations to have arraykey key types */
   ): darray<Tk, Tv> {
     $result = darray[];
     foreach ($traversable as $key => $value) {

--- a/thrift/lib/hack/src/protocol/IRxTProtocol.php
+++ b/thrift/lib/hack/src/protocol/IRxTProtocol.php
@@ -1,0 +1,74 @@
+<?hh // partial
+
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+interface IRxTProtocol {
+
+  <<__Rx, __Mutable>>
+  public function readStructBegin(inout $name);
+  <<__Rx, __Mutable>>
+  public function readStructEnd();
+
+  <<__Rx, __Mutable>>
+  public function readFieldBegin(
+    inout $name,
+    inout $field_type,
+    inout $field_id,
+  );
+  <<__Rx, __Mutable>>
+  public function readFieldEnd();
+
+  <<__Rx, __Mutable>>
+  public function readMapBegin(inout $key_type, inout $val_type, inout $size);
+  <<__Rx, __Mutable>>
+  public function readMapHasNext(): bool;
+  <<__Rx, __Mutable>>
+  public function readMapEnd();
+
+  <<__Rx, __Mutable>>
+  public function readListBegin(inout $elem_type, inout $size);
+  <<__Rx, __Mutable>>
+  public function readListHasNext(): bool;
+  <<__Rx, __Mutable>>
+  public function readListEnd();
+
+  <<__Rx, __Mutable>>
+  public function readSetBegin(inout $elem_type, inout $size);
+  <<__Rx, __Mutable>>
+  public function readSetHasNext(): bool;
+  <<__Rx, __Mutable>>
+  public function readSetEnd();
+
+  <<__Rx, __Mutable>>
+  public function readBool(inout $bool);
+  <<__Rx, __Mutable>>
+  public function readByte(inout $byte);
+  <<__Rx, __Mutable>>
+  public function readI16(inout $i16);
+  <<__Rx, __Mutable>>
+  public function readI32(inout $i32);
+  <<__Rx, __Mutable>>
+  public function readI64(inout $i64);
+  <<__Rx, __Mutable>>
+  public function readDouble(inout $dub);
+  <<__Rx, __Mutable>>
+  public function readFloat(inout $flt);
+  <<__Rx, __Mutable>>
+  public function readString(inout $str);
+
+  <<__Rx, __Mutable>>
+  public function skip($type);
+}

--- a/thrift/lib/hack/src/protocol/TProtocol.php
+++ b/thrift/lib/hack/src/protocol/TProtocol.php
@@ -1,41 +1,36 @@
-<?hh
+<?hh // partial
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Protocol base class module.
  */
 abstract class TProtocol {
-  // The below may seem silly, but it is to get around the problem that the
-  // "instanceof" operator can only take in a T_VARIABLE and not a T_STRING
-  // or T_CONSTANT_ENCAPSED_STRING. Using "is_a()" instead of "instanceof" is
-  // a workaround but is deprecated in PHP5. This is used in the generated
-  // deserialization code.
-  public static $TBINARYPROTOCOLACCELERATED = 'TBinaryProtocolAccelerated';
-  public static $TCOMPACTPROTOCOLACCELERATED = 'TCompactProtocolAccelerated';
-  public static
-    $TBINARYPROTOCOLUNACCELERATED = 'TBinaryProtocolUnaccelerated';
-  public static
-    $TCOMPACTPROTOCOLUNACCELERATED = 'TCompactProtocolUnaccelerated';
 
   /**
    * Underlying transport
    *
    * @var TTransport
    */
-  protected TTransport $trans_;
+  protected /*Sometimes assigned null*/ WRONG_TYPE_HH_FIXME<TTransport> $trans_;
 
   /**
    * Constructor
    */
+  <<__Rx>>
   protected function __construct($trans) {
     $this->trans_ = $trans;
   }
@@ -45,15 +40,15 @@ abstract class TProtocol {
    *
    * @return TTransport
    */
-  public function getTransport() {
+  public function getTransport(): TTransport {
     return $this->trans_;
   }
 
   // NOTE: These are deprecated
-  public function getOutputTransport() {
+  public function getOutputTransport(): TTransport {
     return $this->trans_;
   }
-  public function getInputTransport() {
+  public function getInputTransport(): TTransport {
     return $this->trans_;
   }
 
@@ -97,21 +92,21 @@ abstract class TProtocol {
    * @throws TException on write error
    * @return int How many bytes written
    */
-  public abstract function writeFieldBegin($fieldName, $fieldType, $fieldId);
+  public abstract function writeFieldBegin($field_name, $field_type, $field_id);
 
   public abstract function writeFieldEnd();
 
   public abstract function writeFieldStop();
 
-  public abstract function writeMapBegin($keyType, $valType, $size);
+  public abstract function writeMapBegin($key_type, $val_type, $size);
 
   public abstract function writeMapEnd();
 
-  public abstract function writeListBegin($elemType, $size);
+  public abstract function writeListBegin($elem_type, $size);
 
   public abstract function writeListEnd();
 
-  public abstract function writeSetBegin($elemType, $size);
+  public abstract function writeSetBegin($elem_type, $size);
 
   public abstract function writeSetEnd();
 
@@ -155,61 +150,64 @@ abstract class TProtocol {
 
   public abstract function readFieldBegin(
     inout $name,
-    inout $fieldType,
-    inout $fieldId,
+    inout $field_type,
+    inout $field_id,
   );
 
   public abstract function readFieldEnd();
 
   public abstract function readMapBegin(
-    inout $keyType,
-    inout $valType,
+    inout $key_type,
+    inout $val_type,
     inout $size,
   );
 
+  <<__Rx, __OnlyRxIfImpl(IRxTProtocol::class), __Mutable>>
   public function readMapHasNext(): bool {
     throw new TProtocolException(
-      get_called_class().' does not support unknown map sizes',
+      static::class.' does not support unknown map sizes',
     );
   }
 
   public abstract function readMapEnd();
 
-  public abstract function readListBegin(&$elemType, &$size);
+  public abstract function readListBegin(inout $elem_type, inout $size);
 
+  <<__Rx, __OnlyRxIfImpl(IRxTProtocol::class), __Mutable>>
   public function readListHasNext(): bool {
     throw new TProtocolException(
-      get_called_class().' does not support unknown list sizes',
+      static::class.' does not support unknown list sizes',
     );
   }
 
   public abstract function readListEnd();
 
-  public abstract function readSetBegin(&$elemType, &$size);
+  public abstract function readSetBegin(inout $elem_type, inout $size);
 
+  <<__Rx, __OnlyRxIfImpl(IRxTProtocol::class), __Mutable>>
   public function readSetHasNext(): bool {
     throw new TProtocolException(
-      get_called_class().' does not support unknown set sizes',
+      static::class.' does not support unknown set sizes',
     );
   }
 
   public abstract function readSetEnd();
 
-  public abstract function readBool(&$bool);
+  public abstract function readBool(inout $bool);
 
-  public abstract function readByte(&$byte);
+  public abstract function readByte(inout $byte);
 
-  public abstract function readI16(&$i16);
+  public abstract function readI16(inout $i16);
 
-  public abstract function readI32(&$i32);
+  public abstract function readI32(inout $i32);
 
-  public abstract function readI64(&$i64);
+  public abstract function readI64(inout $i64);
 
-  public abstract function readDouble(&$dub);
+  public abstract function readDouble(inout $dub);
 
-  public abstract function readFloat(&$flt);
+  public abstract function readFloat(inout $flt);
 
-  public abstract function readString(&$str);
+  public abstract function readString(inout $str);
 
   /**
    * The skip function is a utility to parse over unrecognized date without
@@ -217,88 +215,97 @@ abstract class TProtocol {
    *
    * @param TType $type What type is it
    */
+  <<__Rx, __OnlyRxIfImpl(IRxTProtocol::class), __Mutable>>
   public function skip($type) {
     $_ref = null;
     switch ($type) {
       case TType::BOOL:
-        return $this->readBool($_ref);
+        $result = $this->readBool(inout $_ref);
+        return $result;
       case TType::BYTE:
-        return $this->readByte($_ref);
+        $result = $this->readByte(inout $_ref);
+        return $result;
       case TType::I16:
-        return $this->readI16($_ref);
+        $result = $this->readI16(inout $_ref);
+        return $result;
       case TType::I32:
-        return $this->readI32($_ref);
+        $result = $this->readI32(inout $_ref);
+        return $result;
       case TType::I64:
-        return $this->readI64($_ref);
+        $result = $this->readI64(inout $_ref);
+        return $result;
       case TType::DOUBLE:
-        return $this->readDouble($_ref);
+        $result = $this->readDouble(inout $_ref);
+        return $result;
       case TType::FLOAT:
-        return $this->readFloat($_ref);
+        $result = $this->readFloat(inout $_ref);
+        return $result;
       case TType::STRING:
-        return $this->readString($_ref);
-      case TType::STRUCT: {
-          $result = $this->readStructBegin(inout $_ref);
-          while (true) {
-            $ftype = null;
-            $result += $this->readFieldBegin(
-              inout $_ref,
-              inout $ftype,
-              inout $_ref,
-            );
-            if ($ftype == TType::STOP) {
-              break;
-            }
-            $result += $this->skip($ftype);
-            $result += $this->readFieldEnd();
-          }
-          $result += $this->readStructEnd();
-          return $result;
-        }
-      case TType::MAP: {
-          $keyType = null;
-          $valType = null;
-          $size = 0;
-          $result = $this->readMapBegin(
-            inout $keyType,
-            inout $valType,
-            inout $size,
+        $result = $this->readString(inout $_ref);
+        return $result;
+      case TType::STRUCT:
+        $result = $this->readStructBegin(inout $_ref);
+        while (true) {
+          $ftype = null;
+          $field_res = $this->readFieldBegin(
+            inout $_ref,
+            inout $ftype,
+            inout $_ref,
           );
-          for ($i = 0; $size === null || $i < $size; $i++) {
-            if ($size === null && !$this->readMapHasNext()) {
-              break;
-            }
-            $result += $this->skip($keyType);
-            $result += $this->skip($valType);
+          $result += $field_res;
+          if ($ftype === TType::STOP) {
+            break;
           }
-          $result += $this->readMapEnd();
-          return $result;
+          $result += $this->skip($ftype);
+          $result += $this->readFieldEnd();
         }
+        $result += $this->readStructEnd();
+        return $result;
+      case TType::MAP: {
+        $key_type = null;
+        $val_type = null;
+        $size = 0;
+        $result = $this->readMapBegin(
+          inout $key_type,
+          inout $val_type,
+          inout $size,
+        );
+        for ($i = 0; $size === null || $i < $size; $i++) {
+          if ($size === null && !$this->readMapHasNext()) {
+            break;
+          }
+          $result += $this->skip($key_type);
+          $result += $this->skip($val_type);
+        }
+        $result += $this->readMapEnd();
+        return $result;
+      }
       case TType::SET: {
-          $elemType = null;
-          $size = 0;
-          $result = $this->readSetBegin($elemType, $size);
-          for ($i = 0; $size === null || $i < $size; $i++) {
-            if ($size === null && !$this->readSetHasNext()) {
-              break;
-            }
-            $result += $this->skip($elemType);
+        $elem_type = null;
+        $size = 0;
+        $result = $this->readSetBegin(inout $elem_type, inout $size);
+        for ($i = 0; $size === null || $i < $size; $i++) {
+          if ($size === null && !$this->readSetHasNext()) {
+            break;
           }
-          $result += $this->readSetEnd();
-          return $result;
+          $result += $this->skip($elem_type);
         }
+        $result += $this->readSetEnd();
+        return $result;
+      }
       case TType::LST: {
-          $elemType = null;
-          $size = 0;
-          $result = $this->readListBegin($elemType, $size);
-          for ($i = 0; $size === null || $i < $size; $i++) {
-            if ($size === null && !$this->readSetHasNext()) {
-              break;
-            }
-            $result += $this->skip($elemType);
+        $elem_type = null;
+        $size = 0;
+        $result = $this->readListBegin(inout $elem_type, inout $size);
+        for ($i = 0; $size === null || $i < $size; $i++) {
+          if ($size === null && !$this->readSetHasNext()) {
+            break;
           }
-          $result += $this->readListEnd();
-          return $result;
+          $result += $this->skip($elem_type);
         }
+        $result += $this->readListEnd();
+        return $result;
+      }
       default:
         throw new TProtocolException(
           'Unknown field type: '.$type,
@@ -330,71 +337,69 @@ abstract class TProtocol {
       case TType::FLOAT:
         return $itrans->readAll(4);
       case TType::STRING:
-        $len = unpack('N', $itrans->readAll(4));
+        $len = PHP\unpack('N', $itrans->readAll(4));
         $len = $len[1];
         if ($len > 0x7fffffff) {
           $len = 0 - (($len - 1) ^ 0xffffffff);
         }
         return 4 + $itrans->readAll($len);
       case TType::STRUCT: {
-          $result = 0;
-          while (true) {
-            $ftype = 0;
-            $fid = 0;
-            $data = $itrans->readAll(1);
-            $arr = unpack('c', $data);
-            $ftype = $arr[1];
-            if ($ftype == TType::STOP) {
-              break;
-            }
-            // I16 field id
-            $result += $itrans->readAll(2);
-            $result += self::skipBinary($itrans, $ftype);
+        $result = 0;
+        while (true) {
+          $data = $itrans->readAll(1);
+          $arr = PHP\unpack('c', $data);
+          $ftype = $arr[1];
+          if ($ftype === TType::STOP) {
+            break;
           }
-          return $result;
+          // I16 field id
+          $result += $itrans->readAll(2);
+          $result += self::skipBinary($itrans, $ftype);
         }
+        return $result;
+      }
       case TType::MAP: {
-          // Ktype
-          $data = $itrans->readAll(1);
-          $arr = unpack('c', $data);
-          $ktype = $arr[1];
-          // Vtype
-          $data = $itrans->readAll(1);
-          $arr = unpack('c', $data);
-          $vtype = $arr[1];
-          // Size
-          $data = $itrans->readAll(4);
-          $arr = unpack('N', $data);
-          $size = $arr[1];
-          if ($size > 0x7fffffff) {
-            $size = 0 - (($size - 1) ^ 0xffffffff);
-          }
-          $result = 6;
-          for ($i = 0; $i < $size; $i++) {
-            $result += self::skipBinary($itrans, $ktype);
-            $result += self::skipBinary($itrans, $vtype);
-          }
-          return $result;
+        // Ktype
+        $data = $itrans->readAll(1);
+        $arr = PHP\unpack('c', $data);
+        $ktype = $arr[1];
+        // Vtype
+        $data = $itrans->readAll(1);
+        $arr = PHP\unpack('c', $data);
+        $vtype = $arr[1];
+        // Size
+        $data = $itrans->readAll(4);
+        $arr = PHP\unpack('N', $data);
+        $size = $arr[1];
+        if ($size > 0x7fffffff) {
+          $size = 0 - (($size - 1) ^ 0xffffffff);
         }
+        $result = 6;
+        for ($i = 0; $i < $size; $i++) {
+          $result += self::skipBinary($itrans, $ktype);
+          $result += self::skipBinary($itrans, $vtype);
+        }
+        return $result;
+      }
       case TType::SET:
       case TType::LST: {
-          // Vtype
-          $data = $itrans->readAll(1);
-          $arr = unpack('c', $data);
-          $vtype = $arr[1];
-          // Size
-          $data = $itrans->readAll(4);
-          $arr = unpack('N', $data);
-          $size = $arr[1];
-          if ($size > 0x7fffffff) {
-            $size = 0 - (($size - 1) ^ 0xffffffff);
-          }
-          $result = 5;
-          for ($i = 0; $i < $size; $i++) {
-            $result += self::skipBinary($itrans, $vtype);
-          }
-          return $result;
+        // Vtype
+        $data = $itrans->readAll(1);
+        $arr = PHP\unpack('c', $data);
+        $vtype = $arr[1];
+        // Size
+        $data = $itrans->readAll(4);
+        $arr = PHP\unpack('N', $data);
+        $size = $arr[1];
+        if ($size > 0x7fffffff) {
+          $size = 0 - (($size - 1) ^ 0xffffffff);
         }
+        $result = 5;
+        for ($i = 0; $i < $size; $i++) {
+          $result += self::skipBinary($itrans, $vtype);
+        }
+        return $result;
+      }
       default:
         throw new TProtocolException(
           'Unknown field type: '.$type,

--- a/thrift/lib/hack/src/protocol/TProtocolException.php
+++ b/thrift/lib/hack/src/protocol/TProtocolException.php
@@ -1,15 +1,20 @@
 <?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Protocol module. Contains all the types and definitions needed to implement
  * a protocol encoder/decoder.
@@ -20,7 +25,7 @@
 /**
  * Protocol exceptions
  */
-class TProtocolException extends TException {
+final class TProtocolException extends TException {
   const UNKNOWN = 0;
   const INVALID_DATA = 1;
   const NEGATIVE_SIZE = 2;
@@ -29,6 +34,7 @@ class TProtocolException extends TException {
   const NOT_IMPLEMENTED = 5;
   const MISSING_REQUIRED_FIELD = 6;
 
+  <<__Rx>>
   public function __construct(?string $message = null, int $code = 0) {
     parent::__construct($message, $code);
   }

--- a/thrift/lib/hack/src/protocol/TProtocolFactory.php
+++ b/thrift/lib/hack/src/protocol/TProtocolFactory.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Protocol factory creates protocol objects from transports
  */

--- a/thrift/lib/hack/src/protocol/TProtocolSerializer.php
+++ b/thrift/lib/hack/src/protocol/TProtocolSerializer.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Base class for serializing thrift structs using a TProtocol
  */

--- a/thrift/lib/hack/src/protocol/ThriftSerializationHelper.php
+++ b/thrift/lib/hack/src/protocol/ThriftSerializationHelper.php
@@ -1,0 +1,503 @@
+<?hh // partial
+
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Generic Protocol Reader and Writer
+ */
+abstract final class ThriftSerializationHelper {
+
+  <<__Rx, __AtMostRxAsArgs>>
+  public static function readStruct(
+    <<__OnlyRxIfImpl(IRxTProtocol::class), __Mutable>>
+    TProtocol $protocol,
+    <<__Mutable>> IThriftStruct $object,
+  ): int {
+    $field_name = '';
+    $field_type = 0;
+    $field_id = 0;
+
+    $tspec = $object::SPEC;
+    $xfer = $protocol->readStructBegin(inout $field_name);
+    while (true) {
+      $xfer += $protocol->readFieldBegin(
+        inout $field_name,
+        inout $field_type,
+        inout $field_id,
+      );
+
+      // Break once we reach the end of the struct.
+      if ($field_type === TType::STOP) {
+        break;
+      }
+
+      if ($field_id !== null) {
+        // Compact, Binary and JSON:
+        // These protocols only encode the field id.
+
+        // Versioning:
+        // Skip type if there is a mismatch between the tspec and the
+        // type we obtain from the buffer.
+        if (!isset($tspec[$field_id]) ||
+            $field_type !== $tspec[$field_id]['type']) {
+          $xfer += $protocol->skip($field_type);
+          $xfer += $protocol->readFieldEnd();
+          continue;
+        }
+
+        // This uses the TSPEC to find the field name.
+        $field_name = $tspec[$field_id]['var'];
+      } else {
+        // SimpleJSON:
+        // This protocol only encodes the field name.
+
+        // Versioning:
+        // Skip type if there is a mismatch between the tspec and the
+        // type that we obtain from the buffer.
+        if (!PHP\array_key_exists($field_name, $object::FIELDMAP)) {
+          $xfer += $protocol->skip($field_type);
+          $xfer += $protocol->readFieldEnd();
+          continue;
+        }
+
+        // This uses the TFIELDMAP to find the field id.
+        $field_id = $object::FIELDMAP[$field_name];
+      }
+
+      $tmp = null;
+      $xfer += self::readStructHelper(
+        $protocol,
+        $tspec[$field_id]['type'],
+        inout $tmp,
+        $tspec[$field_id]
+      );
+      /* HH_FIXME[2011] dynamic method is allowed on non dynamic types */
+      $object->$field_name = $tmp;
+
+      $xfer += $protocol->readFieldEnd();
+    }
+    $xfer += $protocol->readStructEnd();
+    return $xfer;
+  }
+
+  <<__Rx, __AtMostRxAsArgs>>
+  public static function readUnion(
+    <<__OnlyRxIfImpl(IRxTProtocol::class), __Mutable>>
+    TProtocol $protocol,
+    <<__Mutable>> IThriftStruct $object,
+    inout $union_enum,
+  ): int {
+    $field_name = '';
+    $field_type = 0;
+    $field_id = 0;
+
+    $tspec = $object::SPEC;
+    $union_enum_name = get_class($object) . "Enum";
+    $union_enum = $union_enum_name::_EMPTY_;
+    $xfer = $protocol->readStructBegin(inout $field_name);
+    while (true) {
+      $xfer += $protocol->readFieldBegin(
+        inout $field_name,
+        inout $field_type,
+        inout $field_id,
+      );
+
+      // Break once we reach the end of the struct.
+      if ($field_type === TType::STOP) {
+        break;
+      }
+
+      if ($field_id !== null) {
+        // Compact, Binary and JSON:
+        // These protocols only encode the field id.
+
+        // Versioning:
+        // Skip type if there is a mismatch between the tspec and the
+        // type we obtain from the buffer.
+        if (!isset($tspec[$field_id]) ||
+            $field_type !== $tspec[$field_id]['type']) {
+          $xfer += $protocol->skip($field_type);
+          $xfer += $protocol->readFieldEnd();
+          continue;
+        }
+
+        // This uses the TSPEC to find the field name.
+        $field_name = $tspec[$field_id]['var'];
+      } else {
+        // SimpleJSON:
+        // This protocol only encodes the field name.
+
+        // Versioning:
+        // Skip type if there is a mismatch between the tspec and the
+        // type that we obtain from the buffer.
+        // Since SimpleJSON doesn't have a field id, we use reflection
+        // to inspect the object for the element.
+        if (!PHP\array_key_exists($field_name, $object::FIELDMAP)) {
+          $xfer += $protocol->skip($field_type);
+          $xfer += $protocol->readFieldEnd();
+          continue;
+        }
+
+        // This uses the TFIELDMAP to find the field id.
+        $field_id = $object::FIELDMAP[$field_name];
+      }
+
+      /* HH_FIXME[2011] dynamic method is allowed on non dynamic types */
+      $field_name_tmp = $object->$field_name;
+      $xfer += self::readStructHelper(
+        $protocol,
+        $tspec[$field_id]['type'],
+        inout $field_name_tmp,
+        $tspec[$field_id]
+      );
+      /* HH_FIXME[2011] dynamic method is allowed on non dynamic types */
+      $object->$field_name = $field_name_tmp;
+      $union_enum = $union_enum_name::coerce($object::FIELDMAP[$field_name]);
+      $xfer += $protocol->readFieldEnd();
+    }
+    $xfer += $protocol->readStructEnd();
+    return $xfer;
+  }
+
+  <<__Rx, __AtMostRxAsArgs>>
+  private static function readStructHelper(
+    <<__OnlyRxIfImpl(IRxTProtocol::class), __Mutable>>
+    TProtocol $protocol,
+    @TType $field_type,
+    inout $object,
+    @IThriftStruct::TGenericSpec $tspec,
+  ): int {
+    $xfer = 0;
+    switch ($field_type) {
+      case TType::BOOL:
+        $xfer += $protocol->readBool(inout $object);
+        break;
+      case TType::BYTE:
+        $xfer += $protocol->readByte(inout $object);
+        break;
+      case TType::I16:
+        $xfer += $protocol->readI16(inout $object);
+        break;
+      case TType::I32:
+        // Enums:
+        // In Hack, enums are encoded as I32s.
+        // This looks into the tspec to distinguish the two of them.
+        // Optimization opportunity: Add a TType of enum and encode that to
+        // the tspec to avoid this if statement.
+        if (Shapes::keyExists($tspec, 'enum')) {
+          $val = null;
+          $xfer += $protocol->readI32(inout $val);
+          $enum_class = $tspec['enum'];
+          $object = $enum_class::coerce($val);
+        } else {
+          $xfer += $protocol->readI32(inout $object);
+        }
+        break;
+      case TType::I64:
+        $xfer += $protocol->readI64(inout $object);
+        break;
+      case TType::DOUBLE:
+        $xfer += $protocol->readDouble(inout $object);
+        break;
+      case TType::FLOAT:
+        $xfer += $protocol->readFloat(inout $object);
+        break;
+      case TType::STRING:
+        $xfer += $protocol->readString(inout $object);
+        break;
+      case TType::LST:
+        $size = 0;
+        $element_type = 0;
+        $xfer += $protocol->readListBegin(inout $element_type, inout $size);
+
+        $list = vec[];
+        for ($i = 0; $size === null || $i < $size; ++$i) {
+          if ($size === null && !$protocol->readListHasNext()) {
+            break;
+          }
+
+          $list_element = null;
+          $xfer += self::readStructHelper(
+            $protocol,
+            Shapes::at($tspec, 'etype'),
+            inout $list_element,
+            Shapes::at($tspec, 'elem'),
+          );
+
+          // If the element type is enum and the enum
+          // does not exist, it will return a null.
+          if ($list_element === null) {
+            continue;
+          }
+
+          $list[] = $list_element;
+        }
+
+        // Convert collection to the correct format.
+        if (Shapes::at($tspec, 'format') === 'harray') {
+          $list = vec($list);
+        } else if (Shapes::at($tspec, 'format') === 'collection') {
+          $list = new Vector($list);
+        } else { // format === 'array'
+          $list = varray($list);
+        }
+
+        $object = $list;
+        $xfer += $protocol->readListEnd();
+        break;
+      case TType::SET:
+        $size = 0;
+        $element_type = 0;
+        $xfer += $protocol->readSetBegin(inout $element_type, inout $size);
+
+        $set = keyset[];
+        for ($i = 0; $size === null || $i < $size; ++$i) {
+          if ($size === null && !$protocol->readSetHasNext()) {
+            break;
+          }
+
+          $set_element = null;
+          $xfer += self::readStructHelper(
+            $protocol,
+            Shapes::at($tspec, 'etype'),
+            inout $set_element,
+            Shapes::at($tspec, 'elem'),
+          );
+
+          // If the element type is enum and the enum
+          // does not exist, it will return a null.
+          if ($set_element === null) {
+            continue;
+          }
+
+          $set[] = $set_element;
+        }
+
+        // Convert collection to the correct format.
+        if (Shapes::at($tspec, 'format') === 'harray') {
+          $set = keyset($set);
+        } else if (Shapes::at($tspec, 'format') === 'collection') {
+          $set = new Set($set);
+        } else { // format === 'array'
+          // When using a set array(), we can't append in the normal way.
+          // Therefore, we need to distinguish between the two types
+          // before we add the element to the set.
+          $tmp = darray[];
+          foreach ($set as $set_element) {
+            $tmp[HH\array_key_cast($set_element)] = true;
+          }
+          $set = $tmp;
+        }
+
+        $object = $set;
+        $xfer += $protocol->readSetEnd();
+        break;
+      case TType::MAP:
+        $size = 0;
+        $key_type = 0;
+        $value_type = 0;
+        $xfer += $protocol->readMapBegin(
+          inout $key_type,
+          inout $value_type,
+          inout $size,
+        );
+
+        $map = dict[];
+        for ($i = 0; $size === null || $i < $size; ++$i) {
+          if ($size === null && !$protocol->readMapHasNext()) {
+            break;
+          }
+
+          $key = null;
+          $val = null;
+          $xfer += self::readStructHelper(
+            $protocol,
+            Shapes::at($tspec, 'ktype'),
+            inout $key,
+            Shapes::at($tspec, 'key'),
+          );
+          $xfer += self::readStructHelper(
+            $protocol,
+            Shapes::at($tspec, 'vtype'),
+            inout $val,
+            Shapes::at($tspec, 'val'),
+          );
+
+          // If the element type is enum and the enum
+          // does not exist, it will return a null.
+          if ($key === null || $val === null) {
+            continue;
+          }
+
+          $map[$key] = $val;
+        }
+
+        // Convert collection to the correct format.
+        if (Shapes::at($tspec, 'format') === 'harray') {
+          $map = dict($map);
+        } else if (Shapes::at($tspec, 'format') === 'collection') {
+          $map = new Map($map);
+        } else { // format === 'array'
+          $map = darray($map);
+        }
+
+        $object = $map;
+        $xfer += $protocol->readMapEnd();
+        break;
+      case TType::STRUCT:
+        $cls = Shapes::at($tspec, 'class');
+        $struct = Rx\mutable(new $cls());
+        $xfer += $struct->read($protocol);
+        $object = Rx\freeze($struct);
+        break;
+      default:
+        $xfer += $protocol->skip($field_type);
+    }
+    return $xfer;
+  }
+
+  public static function writeStruct(
+    TProtocol $protocol,
+    IThriftStruct $object,
+  ): int {
+    $xfer = $protocol->writeStructBegin($object->getName());
+    foreach ($object::SPEC as $field_id => $field) {
+      $field_name = $field['var'];
+
+      // Optionals:
+      // When a field is marked as optional and it's not set then
+      // ignore the field. Otherwise, include default value.
+      // Note: If an optional field has a default value,
+      // it will still be added to the buffer.
+      /* HH_FIXME[2011] dynamic method is allowed on non dynamic types */
+      if (!isset($object->$field_name)) {
+        continue;
+      }
+
+      $field_type = $field['type'];
+      $xfer += $protocol->writeFieldBegin($field_name, $field_type, $field_id);
+      $xfer += self::writeStructHelper(
+        $protocol,
+        $field_type,
+        /* HH_FIXME[2011] dynamic method is allowed on non dynamic types */
+        $object->$field_name,
+        $field,
+      );
+      $xfer += $protocol->writeFieldEnd();
+    }
+    $xfer += $protocol->writeFieldStop();
+    $xfer += $protocol->writeStructEnd();
+    return $xfer;
+  }
+
+  private static function writeStructHelper(
+    TProtocol $protocol,
+    $field_type,
+    $object,
+    $tspec,
+  ): int {
+    $xfer = 0;
+    switch ($field_type) {
+      case TType::BOOL:
+        $xfer += $protocol->writeBool($object);
+        break;
+      case TType::BYTE:
+        $xfer += $protocol->writeByte($object);
+        break;
+      case TType::I16:
+        $xfer += $protocol->writeI16($object);
+        break;
+      case TType::I32:
+        $xfer += $protocol->writeI32($object);
+        break;
+      case TType::I64:
+        $xfer += $protocol->writeI64($object);
+        break;
+      case TType::DOUBLE:
+        $xfer += $protocol->writeDouble($object);
+        break;
+      case TType::FLOAT:
+        $xfer += $protocol->writeFloat($object);
+        break;
+      case TType::STRING:
+        $xfer += $protocol->writeString($object);
+        break;
+      case TType::LST:
+        $xfer += $protocol->writeListBegin($tspec['etype'], PHP\count($object));
+        if ($object !== null) {
+          foreach (PHPism_FIXME::coerceTraversableOrObject($object) as $iter) {
+            $xfer += self::writeStructHelper(
+              $protocol,
+              $tspec['etype'],
+              $iter,
+              $tspec['elem'],
+            );
+          }
+        }
+        $xfer += $protocol->writeListEnd();
+        break;
+      case TType::SET:
+        $xfer += $protocol->writeSetBegin($tspec['etype'], PHP\count($object));
+        if ($object !== null) {
+          foreach ($object as $key => $iter) {
+            $xfer += self::writeStructHelper(
+              $protocol,
+              $tspec['etype'],
+              $tspec['format'] === 'array' ? $key : $iter,
+              $tspec['elem'],
+            );
+          }
+        }
+        $xfer += $protocol->writeSetEnd();
+        break;
+      case TType::MAP:
+        $xfer += $protocol->writeMapBegin(
+          $tspec['ktype'],
+          $tspec['vtype'],
+          PHP\count($object),
+        );
+        if ($object !== null) {
+          foreach (PHPism_FIXME::coerceKeyedTraversableOrObject($object) as $kiter => $viter) {
+            $xfer += self::writeStructHelper(
+              $protocol,
+              $tspec['ktype'],
+              $kiter,
+              $tspec['key'],
+            );
+            $xfer += self::writeStructHelper(
+              $protocol,
+              $tspec['vtype'],
+              $viter,
+              $tspec['val'],
+            );
+          }
+        }
+        $xfer += $protocol->writeMapEnd();
+        break;
+      case TType::STRUCT:
+        if ($object !== null) {
+          $xfer += $object->write($protocol);
+        } else {
+          $xfer += $protocol->writeStructBegin($tspec['class']);
+          $xfer += $protocol->writeStructEnd();
+        }
+        break;
+      default:
+        $xfer += $protocol->skip($field_type);
+    }
+    return $xfer;
+  }
+}

--- a/thrift/lib/hack/src/protocol/ThriftSerializationTrait.php
+++ b/thrift/lib/hack/src/protocol/ThriftSerializationTrait.php
@@ -16,13 +16,19 @@
  * limitations under the License.
  */
 /**
- * Compact Protocol Factory
+ * Trait for Thrift Structs to call into the Serialization Helper
  */
-class TCompactProtocolFactory implements TProtocolFactory {
+trait ThriftSerializationTrait implements IThriftStruct {
 
-  public function __construct() {}
+  <<__Rx, __AtMostRxAsArgs, __Mutable>>
+  public function read(
+    <<__OnlyRxIfImpl(IRxTProtocol::class), __Mutable>>
+    TProtocol $protocol,
+  ): int {
+    return ThriftSerializationHelper::readStruct($protocol, $this);
+  }
 
-  public function getProtocol(TTransport $trans): TProtocol {
-    return new TCompactProtocolAccelerated($trans);
+  public function write(TProtocol $protocol): int {
+    return ThriftSerializationHelper::writeStruct($protocol, $this);
   }
 }

--- a/thrift/lib/hack/src/protocol/ThriftUnionSerializationTrait.php
+++ b/thrift/lib/hack/src/protocol/ThriftUnionSerializationTrait.php
@@ -1,0 +1,40 @@
+<?hh
+
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Trait for Thrift Unions to call into the Serialization Helper
+ */
+trait ThriftUnionSerializationTrait implements IThriftStruct {
+
+  <<__Rx, __AtMostRxAsArgs, __Mutable>>
+  public function read(
+    <<__OnlyRxIfImpl(IRxTProtocol::class), __Mutable>>
+    TProtocol $protocol,
+  ): int {
+    /* HH_IGNORE_ERROR[4053] every thrift union has a _type field */
+    $type = $this->_type;
+    $ret = ThriftSerializationHelper::readUnion($protocol, $this, inout $type);
+    /* HH_IGNORE_ERROR[4053] every thrift union has a _type field */
+    $this->_type = $type;
+    return $ret;
+  }
+
+  public function write(TProtocol $protocol): int {
+    // Writing Structs and Unions is the same procedure.
+    return ThriftSerializationHelper::writeStruct($protocol, $this);
+  }
+}

--- a/thrift/lib/hack/src/protocol/binary/TBinaryProtocol.php
+++ b/thrift/lib/hack/src/protocol/binary/TBinaryProtocol.php
@@ -1,15 +1,20 @@
-<?hh
+<?hh // partial
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol.binary
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Do not use this class.
  *
@@ -20,8 +25,8 @@
 class TBinaryProtocol extends TBinaryProtocolAccelerated {
   public function __construct(
     $trans,
-    $strict_read = false,
-    $strict_write = true,
+    bool $strict_read = false,
+    bool $strict_write = true,
   ) {
     parent::__construct($trans, $strict_read, $strict_write);
   }

--- a/thrift/lib/hack/src/protocol/binary/TBinaryProtocolAccelerated.php
+++ b/thrift/lib/hack/src/protocol/binary/TBinaryProtocolAccelerated.php
@@ -1,15 +1,20 @@
-<?hh
+<?hh // partial
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol.binary
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Accelerated binary protocol: used in conjunction with the thrift_protocol
  * extension for faster deserialization
@@ -17,20 +22,20 @@
 class TBinaryProtocolAccelerated extends TBinaryProtocolBase {
   public function __construct(
     $trans,
-    $strict_read = false,
-    $strict_write = true,
+    bool $strict_read = false,
+    bool $strict_write = true,
   ) {
     // If the transport doesn't implement putBack, wrap it in a
     // TBufferedTransport (which does)
-    if (!($trans instanceof IThriftBufferedTransport)) {
+    if (!($trans is IThriftBufferedTransport)) {
       $trans = new TBufferedTransport($trans);
     }
     parent::__construct($trans, $strict_read, $strict_write);
   }
-  public function isStrictRead() {
+  public function isStrictRead(): bool {
     return $this->strictRead_;
   }
-  public function isStrictWrite() {
+  public function isStrictWrite(): bool {
     return $this->strictWrite_;
   }
 }

--- a/thrift/lib/hack/src/protocol/binary/TBinaryProtocolFactory.php
+++ b/thrift/lib/hack/src/protocol/binary/TBinaryProtocolFactory.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol.binary
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Binary Protocol Factory
  */

--- a/thrift/lib/hack/src/protocol/binary/TBinaryProtocolUnaccelerated.php
+++ b/thrift/lib/hack/src/protocol/binary/TBinaryProtocolUnaccelerated.php
@@ -1,23 +1,28 @@
-<?hh
+<?hh // partial
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol.binary
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Old slow unaccelerated protocol.
  */
 class TBinaryProtocolUnaccelerated extends TBinaryProtocolBase {
   public function __construct(
     $trans,
-    $strict_read = false,
-    $strict_write = true,
+    bool $strict_read = false,
+    bool $strict_write = true,
   ) {
     parent::__construct($trans, $strict_read, $strict_write);
   }

--- a/thrift/lib/hack/src/protocol/binary/TBinarySerializer.php
+++ b/thrift/lib/hack/src/protocol/binary/TBinarySerializer.php
@@ -1,15 +1,20 @@
-<?hh
+<?hh // partial
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol.binary
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Utility class for serializing and deserializing
  * a thrift object using TBinaryProtocolAccelerated.
@@ -21,13 +26,14 @@ class TBinarySerializer extends TProtocolSerializer {
   // a transport in which to serialize an object. It has to
   // be a string. Otherwise we will break the compatibility with
   // normal deserialization.
+  <<__Override>>
   public static function serialize(
     IThriftStruct $object,
     bool $disable_hphp_extension = false,
   ): string {
     $transport = new TMemoryBuffer();
     $protocol = new TBinaryProtocolAccelerated($transport);
-    if (function_exists('thrift_protocol_write_binary') &&
+    if (PHP\function_exists('thrift_protocol_write_binary') &&
         !$disable_hphp_extension) {
       thrift_protocol_write_binary(
         $protocol,
@@ -52,14 +58,16 @@ class TBinarySerializer extends TProtocolSerializer {
     return $transport->getBuffer();
   }
 
+  <<__Override>>
   public static function deserialize<T as IThriftStruct>(
     string $str,
     T $object,
     bool $disable_hphp_extension = false,
+    bool $should_leave_extra = false,
   ): T {
     $transport = new TMemoryBuffer();
     $protocol = new TBinaryProtocolAccelerated($transport);
-    if (function_exists('thrift_protocol_read_binary') &&
+    if (PHP\function_exists('thrift_protocol_read_binary') &&
         !$disable_hphp_extension) {
       $protocol->writeMessageBegin('', TMessageType::REPLY, 0);
       $transport->write($str);

--- a/thrift/lib/hack/src/protocol/compact/TCompactProtocol.php
+++ b/thrift/lib/hack/src/protocol/compact/TCompactProtocol.php
@@ -1,15 +1,20 @@
-<?hh
+<?hh // partial
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol.compact
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Do not use this class.
  *

--- a/thrift/lib/hack/src/protocol/compact/TCompactProtocolAccelerated.php
+++ b/thrift/lib/hack/src/protocol/compact/TCompactProtocolAccelerated.php
@@ -1,15 +1,20 @@
-<?hh
+<?hh // partial
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol.compact
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Accelerated compact protocol: used in conjunction with a Thrift HPHP
  * extension for faster serialization and deserialization. The generated Thrift
@@ -19,14 +24,14 @@ class TCompactProtocolAccelerated extends TCompactProtocolBase {
   // The generated Thrift code calls this as a final check. If it returns true,
   // the HPHP extension will be used; if it returns false, the above PHP code is
   // used as a fallback.
-  public static function checkVersion($v) {
+  public static function checkVersion($v): bool {
     return $v == 1;
   }
 
   public function __construct($trans) {
     // If the transport doesn't implement putBack, wrap it in a
     // TBufferedTransport (which does)
-    if (!($trans instanceof IThriftBufferedTransport)) {
+    if (!($trans is IThriftBufferedTransport)) {
       $trans = new TBufferedTransport($trans);
     }
 

--- a/thrift/lib/hack/src/protocol/compact/TCompactProtocolUnaccelerated.php
+++ b/thrift/lib/hack/src/protocol/compact/TCompactProtocolUnaccelerated.php
@@ -1,15 +1,20 @@
-<?hh
+<?hh // partial
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol.compact
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Old slow unaccelerated protocol.
  */

--- a/thrift/lib/hack/src/protocol/simplejson/TSimpleJSONProtocolContext.php
+++ b/thrift/lib/hack/src/protocol/simplejson/TSimpleJSONProtocolContext.php
@@ -1,19 +1,25 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol.simplejson
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 class TSimpleJSONProtocolContext {
+
+  <<__Rx>>
   final public function __construct(
-    protected TTransport $trans,
-    protected IThriftBufferedTransport $bufTrans,
+    protected TMemoryBuffer $trans,
   ) {}
 
   public function writeStart(): int {
@@ -52,7 +58,7 @@ class TSimpleJSONProtocolContext {
     $count = 0;
     $reading = true;
     while ($reading) {
-      $byte = $this->bufTrans->peek(1, $count);
+      $byte = $this->trans->peek(1, $count);
       switch ($byte) {
         case ' ':
         case "\t":

--- a/thrift/lib/hack/src/protocol/simplejson/TSimpleJSONProtocolListContext.php
+++ b/thrift/lib/hack/src/protocol/simplejson/TSimpleJSONProtocolListContext.php
@@ -1,23 +1,30 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol.simplejson
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 class TSimpleJSONProtocolListContext extends TSimpleJSONProtocolContext {
   private bool $first = true;
 
+  <<__Override>>
   public function writeStart(): int {
     $this->trans->write('[');
     return 1;
   }
 
+  <<__Override>>
   public function writeSeparator(): int {
     if ($this->first) {
       $this->first = false;
@@ -28,21 +35,24 @@ class TSimpleJSONProtocolListContext extends TSimpleJSONProtocolContext {
     return 1;
   }
 
+  <<__Override>>
   public function writeEnd(): int {
     $this->trans->write(']');
     return 1;
   }
 
+  <<__Override>>
   public function readStart(): void {
     $this->skipWhitespace();
     $c = $this->trans->readAll(1);
     if ($c !== '[') {
       throw new TProtocolException(
-        'TSimpleJSONProtocol: Expected "[", encountered 0x'.bin2hex($c),
+        'TSimpleJSONProtocol: Expected "[", encountered 0x'.PHP\bin2hex($c),
       );
     }
   }
 
+  <<__Override>>
   public function readSeparator(): void {
     if ($this->first) {
       $this->first = false;
@@ -53,34 +63,37 @@ class TSimpleJSONProtocolListContext extends TSimpleJSONProtocolContext {
     $c = $this->trans->readAll(1);
     if ($c !== ',') {
       throw new TProtocolException(
-        'TSimpleJSONProtocol: Expected ",", encountered 0x'.bin2hex($c),
+        'TSimpleJSONProtocol: Expected ",", encountered 0x'.PHP\bin2hex($c),
       );
     }
   }
 
+  <<__Override>>
   public function readContextOver(): bool {
     $pos = $this->skipWhitespace(false);
-    $c = $this->bufTrans->peek(1, $pos);
+    $c = $this->trans->peek(1, $pos);
     if (!$this->first && $c !== ',' && $c !== ']') {
       throw new TProtocolException(
         'TSimpleJSONProtocol: Expected "," or "]", encountered 0x'.
-        bin2hex($c),
+        PHP\bin2hex($c),
       );
     }
 
     return ($c === ']');
   }
 
+  <<__Override>>
   public function readEnd(): void {
     $this->skipWhitespace();
     $c = $this->trans->readAll(1);
     if ($c !== ']') {
       throw new TProtocolException(
-        'TSimpleJSONProtocol: Expected "]", encountered 0x'.bin2hex($c),
+        'TSimpleJSONProtocol: Expected "]", encountered 0x'.PHP\bin2hex($c),
       );
     }
   }
 
+  <<__Override>>
   public function escapeNum(): bool {
     return false;
   }

--- a/thrift/lib/hack/src/protocol/simplejson/TSimpleJSONProtocolMapContext.php
+++ b/thrift/lib/hack/src/protocol/simplejson/TSimpleJSONProtocolMapContext.php
@@ -1,24 +1,31 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol.simplejson
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 class TSimpleJSONProtocolMapContext extends TSimpleJSONProtocolContext {
   private bool $first = true;
   private bool $colon = true;
 
+  <<__Override>>
   public function writeStart(): int {
     $this->trans->write('{');
     return 1;
   }
 
+  <<__Override>>
   public function writeSeparator(): int {
     if ($this->first) {
       $this->first = false;
@@ -35,21 +42,24 @@ class TSimpleJSONProtocolMapContext extends TSimpleJSONProtocolContext {
     return 1;
   }
 
+  <<__Override>>
   public function writeEnd(): int {
     $this->trans->write('}');
     return 1;
   }
 
+  <<__Override>>
   public function readStart(): void {
     $this->skipWhitespace();
     $c = $this->trans->readAll(1);
     if ($c !== '{') {
       throw new TProtocolException(
-        'TSimpleJSONProtocol: Expected "{", encountered 0x'.bin2hex($c),
+        'TSimpleJSONProtocol: Expected "{", encountered 0x'.PHP\bin2hex($c),
       );
     }
   }
 
+  <<__Override>>
   public function readSeparator(): void {
     if ($this->first) {
       $this->first = false;
@@ -65,36 +75,39 @@ class TSimpleJSONProtocolMapContext extends TSimpleJSONProtocolContext {
         'TSimpleJSONProtocol: Expected "'.
         $target.
         '", encountered 0x'.
-        bin2hex($c),
+        PHP\bin2hex($c),
       );
     }
 
     $this->colon = !$this->colon;
   }
 
+  <<__Override>>
   public function readContextOver(): bool {
     $pos = $this->skipWhitespace(false);
-    $c = $this->bufTrans->peek(1, $pos);
+    $c = $this->trans->peek(1, $pos);
     if (!$this->first && $c !== ',' && $c !== '}') {
       throw new TProtocolException(
         'TSimpleJSONProtocol: Expected "," or "}", encountered 0x'.
-        bin2hex($c),
+        PHP\bin2hex($c),
       );
     }
 
     return ($c === '}');
   }
 
+  <<__Override>>
   public function readEnd(): void {
     $this->skipWhitespace();
     $c = $this->trans->readAll(1);
     if ($c !== '}') {
       throw new TProtocolException(
-        'TSimpleJSONProtocol: Expected "}", encountered 0x'.bin2hex($c),
+        'TSimpleJSONProtocol: Expected "}", encountered 0x'.PHP\bin2hex($c),
       );
     }
   }
 
+  <<__Override>>
   public function escapeNum(): bool {
     return $this->colon;
   }

--- a/thrift/lib/hack/src/protocol/simplejson/TSimpleJSONSerializer.php
+++ b/thrift/lib/hack/src/protocol/simplejson/TSimpleJSONSerializer.php
@@ -1,34 +1,32 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol.simplejson
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Utility class for serializing
- * a thrift object using TSimpleJSONProtocol
+ * a thrift object using TSimpleJSONProtocol.
+ *
+ * DEPRECATED: Use JSONThriftSerializer instead. It's faster.
  */
-class TSimpleJSONSerializer extends TProtocolSerializer {
+class TSimpleJSONSerializer {
+  <<__Deprecated('Use JSONThriftSerializer')>>
   public static function serialize(IThriftStruct $object): string {
     $transport = new TMemoryBuffer();
     $protocol = new TSimpleJSONProtocol($transport);
     $object->write($protocol);
     return $transport->getBuffer();
-  }
-
-  public static function deserialize<T as IThriftStruct>(
-    string $str,
-    T $object,
-  ): T {
-    $transport = new TMemoryBuffer($str);
-    $protocol = new TSimpleJSONProtocol($transport);
-    $object->read($protocol);
-    return $object;
   }
 }

--- a/thrift/lib/hack/src/protocol/simplephpobject/TSimplePHPObjectProtocol.php
+++ b/thrift/lib/hack/src/protocol/simplephpobject/TSimplePHPObjectProtocol.php
@@ -1,420 +1,495 @@
-<?hh
+<?hh // partial
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.protocol.simplephpobject
-*/
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+class TSimplePHPObjectProtocol extends TProtocol implements IRxTProtocol {
 
-class TSimplePHPObjectProtocol extends TProtocol {
+  // 'copy-on-write iterator'. tuple tracks (position, iterable).
+  const type TCOWIterator = (int, vec<mixed>);
+  private vec<this::TCOWIterator> $stack;
 
-  private Iterator<mixed> $top;
-  private Vector<Iterator<mixed>> $stack;
-
+  <<__Rx>>
   public function __construct(mixed $val) {
-    $this->top = new ArrayIterator(array($val));
-    $this->stack = Vector {$this->top};
+    $this->stack = vec[tuple(0, vec[$val])];
     parent::__construct(new TNullTransport());
   }
 
-  public function readMessageBegin(inout $name, inout $type, inout $seqid) {
+  <<__Override>>
+  public function readMessageBegin(
+    inout $name,
+    inout $type,
+    inout $seqid,
+  ): void {
     throw new TProtocolException('Not Supported');
   }
 
-  public function readMessageEnd() {
+  <<__Override>>
+  public function readMessageEnd(): void {
     throw new TProtocolException('Not Supported');
   }
 
-  public function readStructBegin(inout $name) {
+  <<__Rx, __MutableReturn>>
+  public static function toThriftObject<T as IThriftStruct>(
+    mixed $simple_object,
+    <<__OwnedMutable>> T $thrift_object,
+  ): T {
+    $thrift_object->read(
+      Rx\mutable(new TSimplePHPObjectProtocol($simple_object)),
+    );
+    return $thrift_object;
+  }
+
+  <<__Override, __Rx, __Mutable>>
+  public function readStructBegin(inout $name): void {
     $name = null;
-    $val = $this->top->current();
-    $this->top->next();
-    $itr = null;
-    if ($val instanceof Set || $val instanceof ImmSet) {
+    $val = $this->stackTopIterCurrent();
+    $this->stackTopIterNext();
+    if ($val is Set<_> || $val is ImmSet<_>) {
       throw new TProtocolException(
-        'Unsupported data structure for struct: '.gettype($val),
+        'Unsupported data structure for struct: '.PHP\gettype($val),
       );
-    } else if ($val instanceof Vector) {
-      if ($val->isEmpty()) {
+    } else if ($val is Vector<_> || $val is ImmVector<_>) {
+      if (($val as ConstVector<_>)->isEmpty()) {
         // Empty maps can be (de)serialized incorrectly as vectors
-        $size = 0;
-        $itr = $val->getIterator();
+        $itr = vec[];
       } else {
         throw new TProtocolException(
-          'Unsupported data structure for struct: '.gettype($val),
+          'Unsupported data structure for struct: '.PHP\gettype($val),
         );
       }
-    } else if ($val instanceof ImmVector) {
-      if ($val->isEmpty()) {
-        // Empty maps can be (de)serialized incorrectly as vectors
-        $size = 0;
-        $itr = $val->getIterator();
-      } else {
-        throw new TProtocolException(
-          'Unsupported data structure for struct: '.gettype($val),
-        );
-      }
-    } else if ($val instanceof Map) {
-      $itr = $val->getIterator();
-    } else if ($val instanceof ImmMap) {
-      $itr = $val->getIterator();
-    } else if (is_array($val)) {
-      $itr = new ArrayIterator($val);
+    } else if ($val is dict<_, _>) {
+      $itr = PHPArrayism::intishDarrayCast($val);
+    } else if ($val is KeyedContainer<_, _>) {
+      $itr = $val;
     } else {
-      $val = (array) $val;
-      $itr = new ArrayIterator($val);
+      $itr = PHPism_FIXME::arrayCast($val);
     }
-    $itr = new TSimplePHPObjectProtocolKeyedIteratorWrapper($itr);
-    $this->stack->add($itr);
-    $this->top = $itr;
+    $itr = self::flattenMap($itr);
+    $this->stackPush($itr);
   }
 
-  public function readStructEnd() {
-    $this->stack->pop();
-    $val = $this->stack->lastValue();
-    invariant($val !== null, "Stack is empty, this shouldn't happen!");
-    $this->top = $val;
+  <<__Override, __Rx, __Mutable>>
+  public function readStructEnd(): void {
+    $this->stackPopBack();
   }
 
+  <<__Override, __Rx, __Mutable>>
   public function readFieldBegin(
     inout $name,
     inout $fieldType,
     inout $fieldId,
-  ) {
+  ): void {
     $val = null;
     while ($val === null) {
-      if (!$this->top->valid()) {
+      if (!$this->stackTopIterValid()) {
         $fieldType = TType::STOP;
         return;
       }
 
       $fieldId = null;
-      $name = $this->top->current();
-      $this->top->next();
-      $val = $this->top->current();
+      $name = $this->stackTopIterCurrent();
+      $this->stackTopIterNext();
+      $val = $this->stackTopIterCurrent();
       if ($val === null) {
-        $this->top->next();
+        $this->stackTopIterNext();
         continue;
       }
 
-      $fieldType = $this->guessTypeForValue($val);
+      $fieldType = self::guessTypeForValue($val);
     }
   }
 
-  public function readFieldEnd() {}
+  <<__Override, __Rx, __Mutable>>
+  public function readFieldEnd(): void {}
 
-  public function readMapBegin(inout $keyType, inout $valType, inout $size) {
-    $val = $this->top->current();
-    $this->top->next();
-    $itr = null;
-    if ($val instanceof Set || $val instanceof ImmSet) {
+  <<__Override, __Rx, __Mutable>>
+  public function readMapBegin(
+    inout $key_type,
+    inout $val_type,
+    inout $size,
+  ): void {
+    $val = $this->stackTopIterCurrent();
+    $this->stackTopIterNext();
+    if ($val is Set<_> || $val is ImmSet<_>) {
       throw new TProtocolException(
-        'Unsupported data structure for map: '.gettype($val),
+        'Unsupported data structure for map: '.PHP\gettype($val),
       );
-    } else if ($val instanceof Vector) {
-      if ($val->isEmpty()) {
+    } else if ($val is Vector<_> || $val is ImmVector<_>) {
+      if (($val as ConstVector<_>)->isEmpty()) {
         // Empty maps can be (de)serialized incorrectly as vectors
-        $size = 0;
-        $itr = $val->getIterator();
+        $itr = vec[];
       } else {
         throw new TProtocolException(
-          'Unsupported data structure for map: '.gettype($val),
+          'Unsupported data structure for map: '.PHP\gettype($val),
         );
       }
-    } else if ($val instanceof ImmVector) {
-      if ($val->isEmpty()) {
-        // Empty maps can be (de)serialized incorrectly as vectors
-        $size = 0;
-        $itr = $val->getIterator();
-      } else {
-        throw new TProtocolException(
-          'Unsupported data structure for map: '.gettype($val),
-        );
-      }
-    } else if ($val instanceof Map) {
-      $itr = $val->getIterator();
-      $size = $val->count();
-    } else if ($val instanceof ImmMap) {
-      $itr = $val->getIterator();
-      $size = $val->count();
-    } else if (is_array($val)) {
-      $itr = new ArrayIterator($val);
-      $size = count($val);
+    } else if ($val is dict<_, _>) {
+      $itr = PHPArrayism::intishDarrayCast($val);
+    } else if ($val is KeyedContainer<_, _>) {
+      $itr = $val;
     } else {
-      $val = (array) $val;
-      $itr = new ArrayIterator($val);
-      $size = count($val);
+      $itr = PHPism_FIXME::arrayCast($val);
     }
-    $itr = new TSimplePHPObjectProtocolKeyedIteratorWrapper($itr);
-    $this->stack->add($itr);
-    $this->top = $itr;
+    $size = C\count($itr);
+    $itr = self::flattenMap($itr);
+    $this->stackPush($itr);
 
-    if ($itr->valid()) {
-      $key_sample = $itr->current();
-      $itr->next();
-      $val_sample = $itr->current();
-      $itr->rewind();
+    if ($this->stackTopIterValid()) {
+      $key_sample = $this->stackTopIterCurrent();
+      $this->stackTopIterNext();
+      $val_sample = $this->stackTopIterCurrent();
+      $this->stackTopIterRewind();
 
-      $keyType = $this->guessTypeForValue($key_sample);
-      $valType = $this->guessTypeForValue($val_sample);
+      $key_type = self::guessTypeForValue($key_sample);
+      $val_type = self::guessTypeForValue($val_sample);
     }
   }
 
-  public function readMapEnd() {
-    $this->stack->pop();
-    $val = $this->stack->lastValue();
-    invariant($val !== null, "Stack is empty, this shouldn't happen!");
-    $this->top = $val;
+  <<__Override, __Rx, __Mutable>>
+  public function readMapEnd(): void {
+    $this->stackPopBack();
   }
 
-  public function readListBegin(&$elemType, &$size) {
-    $val = $this->top->current();
-    $this->top->next();
-    $itr = null;
-    if ($val instanceof Set || $val instanceof ImmSet) {
+  <<__Override, __Rx, __Mutable>>
+  public function readListBegin(inout $elem_type, inout $size): void {
+    $val = $this->stackTopIterCurrent();
+    $this->stackTopIterNext();
+    if ($val is Set<_> || $val is ImmSet<_> || $val is string) {
       throw new TProtocolException(
-        'Unsupported data structure for list: '.gettype($val),
+        'Unsupported data structure for list: '.PHP\gettype($val),
       );
-    } else if ($val instanceof Map) {
-      $itr = $val->getIterator();
-      $size = $val->count();
-    } else if ($val instanceof ImmMap) {
-      $itr = $val->getIterator();
-      $size = $val->count();
-    } else if ($val instanceof Vector) {
-      $itr = $val->getIterator();
-      $size = $val->count();
-    } else if ($val instanceof ImmVector) {
-      $itr = $val->getIterator();
-      $size = $val->count();
-    } else if (is_array($val)) {
-      $itr = new ArrayIterator($val);
-      $size = count($val);
+    } else if ($val is dict<_, _>) {
+      $itr = PHPArrayism::intishDarrayCast($val);
+    } else if ($val is KeyedContainer<_, _>) {
+      $itr = $val;
     } else {
-      $val = (array) $val;
-      $itr = new ArrayIterator($val);
-      $size = count($val);
+      $itr = PHPism_FIXME::arrayCast($val);
     }
-    $this->stack->add($itr);
-    $this->top = $itr;
+    $size = C\count($itr);
+    $itr = vec($itr);
+    $this->stackPush($itr);
 
-    if ($itr->valid()) {
-      $val_sample = $itr->current();
-      $elemType = $this->guessTypeForValue($val_sample);
+    if ($this->stackTopIterValid()) {
+      $val_sample = $this->stackTopIterCurrent();
+      $elem_type = self::guessTypeForValue($val_sample);
     }
   }
 
-  public function readListEnd() {
-    $this->stack->pop();
-    $val = $this->stack->lastValue();
-    invariant($val !== null, "Stack is empty, this shouldn't happen!");
-    $this->top = $val;
+  <<__Override, __Rx, __Mutable>>
+  public function readListEnd(): void {
+    $this->stackPopBack();
   }
 
-  public function readSetBegin(&$elemType, &$size) {
-    $val = $this->top->current();
-    $this->top->next();
-    $itr = null;
-    if ($val instanceof Map) {
-      $itr = $val->getIterator();
-      $size = $val->count();
-    } else if ($val instanceof ImmMap) {
-      $itr = $val->getIterator();
-      $size = $val->count();
-    } else if ($val instanceof Vector) {
-      $itr = $val->getIterator();
-      $size = $val->count();
-    } else if ($val instanceof ImmVector) {
-      $itr = $val->getIterator();
-      $size = $val->count();
-    } else if ($val instanceof Set) {
-      $itr = $val->getIterator();
-      $size = $val->count();
-    } else if ($val instanceof ImmSet) {
-      $itr = $val->getIterator();
-      $size = $val->count();
-    } else if (is_array($val)) {
-      $itr = new ArrayIterator($val);
-      $size = count($val);
+  <<__Override, __Rx, __Mutable>>
+  public function readSetBegin(inout $elem_type, inout $size): void {
+    $val = $this->stackTopIterCurrent();
+    $this->stackTopIterNext();
+    if ($val is dict<_, _>) {
+      $itr = PHP\fb\varray_map(fun('HH\\array_key_cast'), PHP\array_keys($val));
+    } else if ($val is Container<_>) {
+      $itr = $val;
     } else {
-      $val = array_keys((array) $val);
-      $itr = new ArrayIterator($val);
-      $size = count($val);
+      $itr = PHP\array_keys(PHPism_FIXME::arrayCast($val));
     }
-    $this->stack->add($itr);
-    $this->top = $itr;
+    $size = C\count($itr);
+    $itr = vec($itr);
+    $this->stackPush($itr);
 
-    if ($itr->valid()) {
-      $val_sample = $itr->current();
-      $elemType = $this->guessTypeForValue($val_sample);
+    if ($this->stackTopIterValid()) {
+      $val_sample = $this->stackTopIterCurrent();
+      $elem_type = self::guessTypeForValue($val_sample);
     }
   }
 
-  public function readSetEnd() {
-    $this->stack->pop();
-    $val = $this->stack->lastValue();
-    invariant($val !== null, "Stack is empty, this shouldn't happen!");
-    $this->top = $val;
+  <<__Override, __Rx, __Mutable>>
+  public function readSetEnd(): void {
+    $this->stackPopBack();
   }
 
-  public function readBool(&$value) {
-    $value = (bool) $this->top->current();
-    $this->top->next();
+  <<__Override, __Rx, __Mutable>>
+  public function readBool(inout $value): void {
+    $value = (bool)$this->stackTopIterCurrent();
+    $this->stackTopIterNext();
   }
 
-  public function readByte(&$value) {
-    $value = (int) $this->top->current();
-    $this->top->next();
+  <<__Override, __Rx, __Mutable>>
+  public function readByte(inout $value): void {
+    $value = (int)$this->stackTopIterCurrent();
+    $this->stackTopIterNext();
     if ($value < -0x80 || $value > 0x7F) {
       throw new TProtocolException('Value is outside of valid range');
     }
   }
 
-  public function readI16(&$value) {
-    $value = (int) $this->top->current();
-    $this->top->next();
+  <<__Override, __Rx, __Mutable>>
+  public function readI16(inout $value): void {
+    $value = (int)$this->stackTopIterCurrent();
+    $this->stackTopIterNext();
     if ($value < -0x8000 || $value > 0x7FFF) {
       throw new TProtocolException('Value is outside of valid range');
     }
   }
 
-  public function readI32(&$value) {
-    $value = (int) $this->top->current();
-    $this->top->next();
+  <<__Override, __Rx, __Mutable>>
+  public function readI32(inout $value): void {
+    $value = (int)$this->stackTopIterCurrent();
+    $this->stackTopIterNext();
     if ($value < -0x80000000 || $value > 0x7FFFFFFF) {
       throw new TProtocolException('Value is outside of valid range');
     }
   }
 
-  public function readI64(&$value) {
-    $value = (int) $this->top->current();
-    $this->top->next();
-    if ($value < (-0x80000000 << 32) ||
-        $value > (0x7FFFFFFF << 32 | 0xFFFFFFFF)) {
+  <<__Override, __Rx, __Mutable>>
+  public function readI64(inout $value): void {
+    $value = (int)$this->stackTopIterCurrent();
+    $this->stackTopIterNext();
+    if (
+      $value < (-0x80000000 << 32) || $value > (0x7FFFFFFF << 32 | 0xFFFFFFFF)
+    ) {
       throw new TProtocolException('Value is outside of valid range');
     }
   }
 
-  public function readDouble(&$value) {
-    $value = (float) $this->top->current();
-    $this->top->next();
+  <<__Override, __Rx, __Mutable>>
+  public function readDouble(inout $value): void {
+    $value = (float)$this->stackTopIterCurrent();
+    $this->stackTopIterNext();
   }
 
-  public function readFloat(&$value) {
-    $value = (float) $this->top->current();
-    $this->top->next();
+  <<__Override, __Rx, __Mutable>>
+  public function readFloat(inout $value): void {
+    $value = (float)$this->stackTopIterCurrent();
+    $this->stackTopIterNext();
   }
 
-  public function readString(&$value) {
-    $value = (string) $this->top->current();
-    $this->top->next();
+  <<__Override, __Rx, __Mutable>>
+  public function readString(inout $value): void {
+    $value = (string)$this->stackTopIterCurrent();
+    $this->stackTopIterNext();
   }
 
-  public function writeMessageBegin($name, $type, $seqid) {
+  <<__Override>>
+  public function writeMessageBegin($name, $type, $seqid): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeMessageEnd() {
+  <<__Override>>
+  public function writeMessageEnd(): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeStructBegin($name) {
+  <<__Override>>
+  public function writeStructBegin($name): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeStructEnd() {
+  <<__Override>>
+  public function writeStructEnd(): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeFieldBegin($fieldName, $fieldType, $fieldId) {
+  <<__Override>>
+  public function writeFieldBegin($fieldName, $fieldType, $fieldId): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeFieldEnd() {
+  <<__Override>>
+  public function writeFieldEnd(): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeFieldStop() {
+  <<__Override>>
+  public function writeFieldStop(): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeMapBegin($keyType, $valType, $size) {
+  <<__Override>>
+  public function writeMapBegin($keyType, $valType, $size): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeMapEnd() {
+  <<__Override>>
+  public function writeMapEnd(): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeListBegin($elemType, $size) {
+  <<__Override>>
+  public function writeListBegin($elemType, $size): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeListEnd() {
+  <<__Override>>
+  public function writeListEnd(): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeSetBegin($elemType, $size) {
+  <<__Override>>
+  public function writeSetBegin($elemType, $size): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeSetEnd() {
+  <<__Override>>
+  public function writeSetEnd(): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeBool($value) {
+  <<__Override>>
+  public function writeBool($value): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeByte($value) {
+  <<__Override>>
+  public function writeByte($value): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeI16($value) {
+  <<__Override>>
+  public function writeI16($value): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeI32($value) {
+  <<__Override>>
+  public function writeI32($value): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeI64($value) {
+  <<__Override>>
+  public function writeI64($value): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeDouble($value) {
+  <<__Override>>
+  public function writeDouble($value): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeFloat($value) {
+  <<__Override>>
+  public function writeFloat($value): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  public function writeString($value) {
+  <<__Override>>
+  public function writeString($value): void {
     throw new TProtocolException('Not Implemented');
   }
 
-  private function guessTypeForValue(mixed $val): int {
-    if (is_bool($val)) {
+  /**
+   * Returns the index of the topmost element in the stack.
+   */
+  <<__Rx, __MaybeMutable>>
+  private function stackTopIdx(): int {
+    return C\count($this->stack) - 1;
+  }
+
+  /**
+   * Returns true if the position of the iterator at the top of the stack is
+   * valid, or false if the position is out of bounds.
+   */
+  <<__Rx, __MaybeMutable>>
+  private function stackTopIterValid(): bool {
+    list($top_pos, $top_iter) = $this->stack[$this->stackTopIdx()];
+    return $top_pos >= 0 && $top_pos < C\count($top_iter);
+  }
+
+  /**
+   * Returns the current element for the iterator at the top of the stack.
+   */
+  <<__Rx, __MaybeMutable>>
+  private function stackTopIterCurrent(): mixed {
+    list($top_pos, $top_iter) = $this->stack[$this->stackTopIdx()];
+    return $top_iter[$top_pos];
+  }
+
+  /**
+   * Moves the position for the iterator at the top of the stack forward.
+   */
+  <<__Rx, __Mutable>>
+  private function stackTopIterNext(): void {
+    $this->stack[$this->stackTopIdx()][0]++;
+  }
+
+  /**
+   * Moves the position for the iterator at the top of the stack backward.
+   */
+  <<__Rx, __Mutable>>
+  private function stackTopIterRewind(): void {
+    $this->stack[$this->stackTopIdx()][0]--;
+  }
+
+  /**
+   * Turns an iterable into a COW iterator and pushes it onto the stack.
+   */
+  <<__Rx, __Mutable>>
+  private function stackPush(vec<mixed> $iterable): void {
+    $this->stack[] = tuple(0, $iterable);
+  }
+
+  /**
+   * Pops the iterator at the top of the stack.
+   */
+  <<__Rx, __Mutable>>
+  private function stackPopBack(): void {
+    /* HH_FIXME[4135] Exposed by banning unset and isset in partial mode */
+    unset($this->stack[$this->stackTopIdx()]);
+    invariant(
+      C\last($this->stack) !== null,
+      'Stack is empty, this shouldn\'t happen!',
+    );
+  }
+
+  /**
+   * Flattens the keys and values of a map sequentially into a vec.
+   *
+   * e.g. dict['foo' => 123, 'bar' => 456] -> vec['foo', 123, 'bar', 456]
+   */
+  <<__Rx>>
+  private static function flattenMap(
+    KeyedContainer<arraykey, mixed> $map,
+  ): vec<mixed> {
+    $res = vec[];
+    foreach ($map as $key => $value) {
+      $res[] = $key;
+      $res[] = $value;
+    }
+    return $res;
+  }
+
+  <<__Rx>>
+  private static function guessTypeForValue(mixed $val): int {
+    if ($val is bool) {
       return TType::BOOL;
-    } else if (is_int($val)) {
+    } else if ($val is int) {
       return TType::I64;
-    } else if (is_float($val)) {
+    } else if ($val is float) {
       return TType::DOUBLE;
-    } else if (is_string($val)) {
+    } else if ($val is string) {
       return TType::STRING;
-    } else if (is_object($val) || is_array($val) || $val instanceof Map) {
+    } else if (
+      PHP\is_object($val) ||
+      is_array($val) ||
+      $val is Map<_, _> ||
+      $val is dict<_, _>
+    ) {
       return TType::STRUCT;
-    } else if ($val instanceof Iterable) {
+    } else if ($val is Iterable<_> || $val is vec<_>) {
       return TType::LST;
     }
 
     throw new TProtocolException(
-      'Unable to guess thrift type for '.gettype($val),
+      'Unable to guess thrift type for '.PHP\gettype($val),
     );
   }
 }

--- a/thrift/lib/hack/src/protocol/simplephpobject/VecIterator.php
+++ b/thrift/lib/hack/src/protocol/simplephpobject/VecIterator.php
@@ -1,0 +1,45 @@
+<?hh
+
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+class VecIterator<T> implements Iterator<T> {
+  private int $currentIndex;
+  public function __construct(private vec<T> $src) {
+    $this->currentIndex = PHP\fb\key($src) ?? 0;
+  }
+
+  public function current(): T {
+    invariant($this->currentIndex < C\count($this->src), 'iterator not valid');
+    return $this->src[$this->currentIndex];
+  }
+
+  public function key(): int {
+    invariant($this->currentIndex < C\count($this->src), 'iterator not valid');
+    return $this->currentIndex;
+  }
+
+  public function next(): void {
+    $this->currentIndex++;
+  }
+
+  public function rewind(): void {
+    $this->currentIndex = 0;
+  }
+
+  public function valid(): bool {
+    return $this->currentIndex < C\count($this->src);
+  }
+}

--- a/thrift/lib/hack/src/server/TNonBlockingServer.php
+++ b/thrift/lib/hack/src/server/TNonBlockingServer.php
@@ -1,21 +1,26 @@
 <?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.server
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Server that can run in non-blocking mode
  */
 class TNonBlockingServer extends TServer {
   protected int $clientIdx = 0;
-  protected array<int, TBufferedTransport> $clients = array();
+  protected darray<int, TBufferedTransport> $clients = darray[];
 
   public function __construct(
     IThriftProcessor $processor,
@@ -37,6 +42,7 @@ class TNonBlockingServer extends TServer {
    *
    * @return bool true if we should keep the client alive
    */
+  <<__Override>>
   protected function handle(TBufferedTransport $client): bool {
     $trans = $this->transportFactory->getTransport($client);
     $prot = $this->protocolFactory->getProtocol($trans);
@@ -45,15 +51,15 @@ class TNonBlockingServer extends TServer {
     try {
       // First check the transport is readable to avoid
       // blocking on read
-      if (!($trans instanceof TTransportStatus) || $trans->isReadable()) {
+      if (!($trans is TTransportStatus) || $trans->isReadable()) {
         $this->processor->process($prot, $prot);
       }
     } catch (Exception $x) {
       $md = $client->getMetaData();
-      if ($md['timed_out']) {
+      if (PHPism_FIXME::nullableTruthyCheck($md['timed_out'])) {
         // keep waiting for the client to send more requests
-      } else if ($md['eof']) {
-        invariant($trans instanceof TTransport, 'Need to make Hack happy');
+      } else if (PHPism_FIXME::nullableTruthyCheck($md['eof'])) {
+        invariant($trans is TTransport, 'Need to make Hack happy');
         $trans->close();
         return false;
       } else {
@@ -78,6 +84,7 @@ class TNonBlockingServer extends TServer {
    * process an request. If there is no pending request, it will
    * return;
    */
+  <<__Override>>
   public function serve(): void {
     $this->serverTransport->listen();
     $this->process();
@@ -87,7 +94,8 @@ class TNonBlockingServer extends TServer {
     // 0 timeout is non-blocking
     $client = $this->serverTransport->accept(0);
     if ($client) {
-      $this->clients[$this->clientIdx++] = $client;
+      $this->clients[$this->clientIdx] = $client;
+      $this->clientIdx++;
     }
 
     $this->processExistingClients();

--- a/thrift/lib/hack/src/server/TServer.php
+++ b/thrift/lib/hack/src/server/TServer.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.server
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Base interface for a server.
  *

--- a/thrift/lib/hack/src/server/TServerEventHandler.php
+++ b/thrift/lib/hack/src/server/TServerEventHandler.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.server
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Event handler base class.  Override selected methods on this class
  * to implement custom event handling

--- a/thrift/lib/hack/src/transport/IThriftBufferedTransport.php
+++ b/thrift/lib/hack/src/transport/IThriftBufferedTransport.php
@@ -1,17 +1,21 @@
-<?hh
+<?hh // partial
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 interface IThriftBufferedTransport {
   public function peek(int $len, int $start = 0);
   public function putBack(string $data): void;
-  public function minBytesAvailable(): int;
 }

--- a/thrift/lib/hack/src/transport/IThriftRemoteConn.php
+++ b/thrift/lib/hack/src/transport/IThriftRemoteConn.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 interface IThriftRemoteConn extends TTransportStatus {
   public function open(): void;
   public function close(): void;

--- a/thrift/lib/hack/src/transport/InstrumentedTTransport.php
+++ b/thrift/lib/hack/src/transport/InstrumentedTTransport.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 interface InstrumentedTTransport {
   public function getBytesWritten(): int;
   public function getBytesRead(): int;

--- a/thrift/lib/hack/src/transport/InstrumentedTTransportTrait.php
+++ b/thrift/lib/hack/src/transport/InstrumentedTTransportTrait.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * TTransport subclasses that implement InstrumentedTTransport and use
  * InstrumentedTTransportTrait have a simple set of counters available.

--- a/thrift/lib/hack/src/transport/TFileStream.php
+++ b/thrift/lib/hack/src/transport/TFileStream.php
@@ -1,0 +1,155 @@
+<?hh
+
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * File stream transport. Reads to and writes from the file streams
+ *
+ * @package thrift.transport
+ */
+final class TFileStream extends TTransport {
+
+  const int MODE_R = 1;
+  const int MODE_W = 2;
+
+  private ?resource $inStream = null;
+  private ?resource $outStream = null;
+
+  private bool $read = false;
+  private bool $write = false;
+
+  private int $bufferSize = 1024 * 1024;
+  private string $buffer = '';
+  private int $bufferIndex = 0;
+
+  public function __construct(int $mode, private string $filePath) {
+    $this->read = (bool) ($mode & self::MODE_R);
+    $this->write = (bool) ($mode & self::MODE_W);
+  }
+
+  public function setBufferSize(int $buffer_size): this {
+    $this->bufferSize = $buffer_size;
+    return $this;
+  }
+
+  <<__Override>>
+  public function open(): void {
+    if ($this->read) {
+      $this->inStream = PHP\fopen($this->filePath, 'r');
+      if (!($this->inStream is resource)) {
+        throw new TException('TPhpStream: Could not open %s', $this->filePath);
+      }
+    }
+    if ($this->write) {
+      $this->outStream = PHP\fopen($this->filePath, 'w');
+      if (!($this->outStream is resource)) {
+        throw new TException('TPhpStream: Could not open %s', $this->filePath);
+      }
+    }
+  }
+
+  <<__Override>>
+  public function close(): void {
+    if ($this->read) {
+      PHP\fclose(nullthrows($this->inStream));
+      $this->inStream = null;
+    }
+    if ($this->write) {
+      $this->flush();
+      PHP\fclose(nullthrows($this->outStream));
+      $this->outStream = null;
+    }
+  }
+
+  <<__Override>>
+  public function isOpen(): bool {
+    return (!$this->read || $this->inStream is resource) &&
+      (!$this->write || $this->outStream is resource);
+  }
+
+  <<__Override>>
+  public function read(int $len): string {
+    $available_bytes = Str\length($this->buffer) - $this->bufferIndex;
+    if ($available_bytes < $len) {
+      $bytes_to_read = $len - $available_bytes;
+      $data = @PHP\fread(
+        nullthrows($this->inStream),
+        $bytes_to_read + $this->bufferSize,
+      );
+      if ($data === false || $data === '') {
+        throw new TException('TFileStream: Could not read %d bytes', $len);
+      }
+      $result = Str\slice($this->buffer, $this->bufferIndex).
+        Str\slice($data, 0, $bytes_to_read);
+      $this->buffer = Str\slice($data, $bytes_to_read);
+      $this->bufferIndex = 0;
+    } else {
+      if ($len === 1) {
+        $result = $this->buffer[$this->bufferIndex];
+      } else {
+        $result = Str\slice($this->buffer, $this->bufferIndex, $len);
+      }
+      $this->bufferIndex += $len;
+    }
+    return $result;
+  }
+
+  <<__Override>>
+  public function write(string $buf): void {
+    if (Str\length($this->buffer) + Str\length($buf) > $this->bufferSize) {
+      $written = @PHP\fwrite(nullthrows($this->outStream), $this->buffer);
+      if ($written === 0 || $written === false) {
+        throw new TException(
+          'TPhpStream: Could not write %d bytes in buffer',
+          Str\length($this->buffer),
+        );
+      }
+      $written = @PHP\fwrite(nullthrows($this->outStream), $buf);
+      if ($written === 0 || $written === false) {
+        throw new TException(
+          'TPhpStream: Could not write %d bytes in buffer',
+          Str\length($buf),
+        );
+      }
+      $this->buffer = '';
+    } else {
+      $this->buffer .= $buf;
+    }
+  }
+
+  <<__Override>>
+  public function flush(): void {
+    if (Str\length($this->buffer) > 0) {
+      $written = @PHP\fwrite(nullthrows($this->outStream), $this->buffer);
+      if ($written === 0 || $written === false) {
+        throw new TException(
+          'TPhpStream: Could not write %d bytes in buffer',
+          Str\length($this->buffer),
+        );
+      }
+      $this->buffer = '';
+    }
+    PHP\fflush(nullthrows($this->outStream));
+  }
+
+  /**
+   * Name of the transport (e.g.: socket).
+   */
+  <<__Override>>
+  public function getTransportType(): string {
+    return 'filestream';
+  }
+}

--- a/thrift/lib/hack/src/transport/THeaderTransport.php
+++ b/thrift/lib/hack/src/transport/THeaderTransport.php
@@ -1,15 +1,20 @@
-<?hh
+<?hh // partial
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Header transport. Writes and reads data with
  *
@@ -49,7 +54,7 @@ class THeaderTransport extends TFramedTransport
   protected int $protoId_ = self::TBINARY_PROTOCOL;
   protected int $clientType_ = self::HEADER_CLIENT_TYPE;
   protected Set<int> $supportedProtocols;
-  protected Vector<int> $readTrans_;
+  protected WRONG_TYPE_HH_FIXME<Vector<int>> $readTrans_;
   protected Vector<int> $writeTrans_;
   protected int $seqId_ = 0;
   protected int $flags_ = 0;
@@ -84,6 +89,7 @@ class THeaderTransport extends TFramedTransport
       self::UNFRAMED_DEPRECATED,
       self::HTTP_CLIENT_TYPE,
     };
+    /* HH_FIXME[4276] Exposed by wrapping bad truthiness checks */
     if ($protocols) {
       $this->supportedProtocols->addAll($protocols);
     }
@@ -111,14 +117,14 @@ class THeaderTransport extends TFramedTransport
     $this->readFrame(0);
   }
 
-  public function setHeader(string $str_key, @string $str_value): this {
+  public function setHeader(string $str_key, string $str_value): this {
     $this->writeHeaders[$str_key] = (string) $str_value;
     return $this;
   }
 
   public function setPersistentHeader(
     string $str_key,
-    @string $str_value,
+    string $str_value,
   ): this {
     $this->persistentWriteHeaders[$str_key] = (string) $str_value;
     return $this;
@@ -166,20 +172,21 @@ class THeaderTransport extends TFramedTransport
    *
    * @param int $len How much data
    */
-  public function read(int $len): @string { // Task #5347782
+  <<__Override>>
+  public function read(int $len): string {
     if ($this->clientType_ === self::UNFRAMED_DEPRECATED) {
       return $this->transport_->readAll($len);
     }
 
-    if (strlen($this->rBuf_) === 0) {
+    if (Str\length($this->rBuf_) === 0) {
       $this->readFrame($len);
     }
 
     // Return substr
-    $out = substr($this->rBuf_, $this->rIndex_, $len);
+    $out = PHP\substr($this->rBuf_, $this->rIndex_, $len);
     $this->rIndex_ += $len;
 
-    if (strlen($this->rBuf_) <= $this->rIndex_) {
+    if (Str\length($this->rBuf_) <= $this->rIndex_) {
       $this->rBuf_ = '';
       $this->rIndex_ = 0;
     }
@@ -191,7 +198,7 @@ class THeaderTransport extends TFramedTransport
    */
   private function readFrame(int $req_sz): void {
     $buf = $this->transport_->readAll(4);
-    $val = unpack('N', $buf);
+    $val = PHP\unpack('N', $buf);
     $sz = $val[1];
 
     if (($sz & TBinaryProtocol::VERSION_MASK) === TBinaryProtocol::VERSION_1) {
@@ -209,7 +216,7 @@ class THeaderTransport extends TFramedTransport
     } else {
       // Either header format or framed. Check next byte
       $buf2 = $this->transport_->readAll(4);
-      $val2 = unpack('N', $buf2);
+      $val2 = PHP\unpack('N', $buf2);
       $version = $val2[1];
       if (($version & TBinaryProtocol::VERSION_MASK) ===
           TBinaryProtocol::VERSION_1) {
@@ -232,15 +239,15 @@ class THeaderTransport extends TFramedTransport
         $this->flags_ = ($version & 0x0000ffff);
         // read seqId
         $buf3 = $this->transport_->readAll(4);
-        $val3 = unpack('N', $buf3);
+        $val3 = PHP\unpack('N', $buf3);
         $this->seqId_ = $val3[1];
         // read header_size
         $buf4 = $this->transport_->readAll(2);
-        $val4 = unpack('n', $buf4);
+        $val4 = PHP\unpack('n', $buf4);
         $header_size = $val4[1];
 
         $data = $buf.$buf2.$buf3.$buf4;
-        $index = strlen($data);
+        $index = Str\length($data);
 
         $data .= $this->transport_->readAll($sz - 10);
         $this->readHeaderFormat($sz - 10, $header_size, $data, $index);
@@ -266,8 +273,9 @@ class THeaderTransport extends TFramedTransport
     $result = 0;
     $shift = 0;
     while (true) {
-      $x = substr($data, $index++, 1);
-      $byte = ord($x);
+      $x = PHP\substr($data, $index, 1);
+      $index++;
+      $byte = PHP\ord($x);
       $result |= ($byte & 0x7f) << $shift;
       if (($byte >> 7) === 0) {
         return $result;
@@ -282,10 +290,10 @@ class THeaderTransport extends TFramedTransport
     $out = "";
     while (true) {
       if (($data & ~0x7f) === 0) {
-        $out .= chr($data);
+        $out .= PHP\chr($data);
         break;
       } else {
-        $out .= chr(($data & 0xff) | 0x80);
+        $out .= PHP\chr(($data & 0xff) | 0x80);
         $data = $data >> 7;
       }
     }
@@ -293,7 +301,7 @@ class THeaderTransport extends TFramedTransport
   }
 
   protected function writeString(string $str): string {
-    $buf = $this->getVarint(strlen($str));
+    $buf = $this->getVarint(Str\length($str));
     $buf .= $str;
     return $buf;
   }
@@ -303,7 +311,7 @@ class THeaderTransport extends TFramedTransport
     int &$index,
     int $limit,
   ): string {
-    $str_sz = $this->readVarint($data, $index);
+    $str_sz = $this->readVarint($data, &$index);
     if ($str_sz + $index > $limit) {
       throw new TTransportException(
         'String read too long',
@@ -311,7 +319,7 @@ class THeaderTransport extends TFramedTransport
       );
     }
 
-    $str = substr($data, $index, $str_sz);
+    $str = PHP\substr($data, $index, $str_sz);
     $index += $str_sz;
     return $str;
   }
@@ -333,8 +341,8 @@ class THeaderTransport extends TFramedTransport
     }
     $end_of_header = $index + $header_size;
 
-    $this->protoId_ = $this->readVarint($data, $index);
-    $numHeaders = $this->readVarint($data, $index);
+    $this->protoId_ = $this->readVarint($data, &$index);
+    $numHeaders = $this->readVarint($data, &$index);
     if ($this->protoId_ === 1 &&
         $this->clientType_ !== self::HTTP_CLIENT_TYPE) {
       throw new TTransportException(
@@ -345,7 +353,7 @@ class THeaderTransport extends TFramedTransport
 
     // Read in the headers.  Data for each header varies.
     for ($i = 0; $i < $numHeaders; $i++) {
-      $transId = $this->readVarint($data, $index);
+      $transId = $this->readVarint($data, &$index);
       switch ($transId) {
         case self::ZLIB_TRANSFORM:
         case self::SNAPPY_TRANSFORM:
@@ -367,18 +375,18 @@ class THeaderTransport extends TFramedTransport
     }
     // Make sure that the read transforms are applied in the reverse order
     // from when the data was written.
-    $this->readTrans_ = array_reverse($this->readTrans_);
+    $this->readTrans_ = PHP\array_reverse($this->readTrans_);
 
     // Read the info headers
     $this->readHeaders = Map {};
     while ($index < $end_of_header) {
-      $infoId = $this->readVarint($data, $index);
+      $infoId = $this->readVarint($data, &$index);
       switch ($infoId) {
         case self::INFO_KEYVALUE:
-          $num_keys = $this->readVarint($data, $index);
+          $num_keys = $this->readVarint($data, &$index);
           for ($i = 0; $i < $num_keys; $i++) {
-            $strKey = $this->readString($data, $index, $end_of_header);
-            $strValue = $this->readString($data, $index, $end_of_header);
+            $strKey = $this->readString($data, &$index, $end_of_header);
+            $strValue = $this->readString($data, &$index, $end_of_header);
             $this->readHeaders[$strKey] = $strValue;
           }
           break;
@@ -389,21 +397,23 @@ class THeaderTransport extends TFramedTransport
     }
 
     $this->rBuf_ =
-      $this->untransform(substr($data, $end_of_header, $sz - $header_size));
+      $this->untransform(PHP\substr($data, $end_of_header, $sz - $header_size));
   }
 
   protected function transform(string $data): string {
-    // UNSAFE_BLOCK: the only way we know that these possibly iterated compressors
+    // the only way we know that these possibly iterated compressors
     // will produce reeasonable results is by complicated promises of the way
     // thrift sets things up, which Hack has no way to understand.
     foreach ($this->writeTrans_ as $trans) {
       switch ($trans) {
         case self::ZLIB_TRANSFORM:
-          $data = gzcompress($data);
+          /* HH_FIXME[4110] errors exposed by removing unsafe annotation */
+          $data = PHP\gzcompress($data);
           break;
 
         case self::SNAPPY_TRANSFORM:
-          $data = sncompress($data);
+          /* HH_FIXME[4110] errors exposed by removing unsafe annotation */
+          $data = PHP\sncompress($data);
           break;
 
         default:
@@ -413,21 +423,24 @@ class THeaderTransport extends TFramedTransport
           );
       }
     }
+    /* HH_FIXME[4110] errors exposed by removing unsafe annotation */
     return $data;
   }
 
-  protected function untransform(string $data): @string { // Task #5347782
-    // UNSAFE_BLOCK: the only way we know that these possibly iterated compressors
+  protected function untransform(string $data): string {
+    // the only way we know that these possibly iterated compressors
     // will produce reeasonable results is by complicated promises of the way
     // thrift sets things up, which Hack has no way to understand.
     foreach ($this->readTrans_ as $trans) {
       switch ($trans) {
         case self::ZLIB_TRANSFORM:
-          $data = gzuncompress($data);
+          /* HH_FIXME[4110] errors exposed by removing unsafe annotation */
+          $data = PHP\gzuncompress($data);
           break;
 
         case self::SNAPPY_TRANSFORM:
-          $data = snuncompress($data);
+          /* HH_FIXME[4110] errors exposed by removing unsafe annotation */
+          $data = PHP\snuncompress($data);
           break;
 
         default:
@@ -437,6 +450,7 @@ class THeaderTransport extends TFramedTransport
           );
       }
     }
+    /* HH_FIXME[4110] errors exposed by removing unsafe annotation */
     return $data;
   }
 
@@ -444,16 +458,18 @@ class THeaderTransport extends TFramedTransport
    * Writes the output buffer in header format, or format
    * client responded with (framed, unframed, http)
    */
+  <<__Override>>
   public function flush(): void {
     $this->flushImpl(false);
   }
 
+  <<__Override>>
   public function onewayFlush(): void {
     $this->flushImpl(true);
   }
 
   private function flushImpl(bool $oneway): void {
-    if (strlen($this->wBuf_) == 0) {
+    if (Str\length($this->wBuf_) == 0) {
       if ($oneway) {
         $this->transport_->onewayFlush();
       } else {
@@ -499,8 +515,8 @@ class THeaderTransport extends TFramedTransport
       if ($this->writeHeaders || $this->persistentWriteHeaders) {
         $infoData .= $this->getVarint(self::INFO_KEYVALUE);
         $infoData .= $this->getVarint(
-          count($this->writeHeaders) +
-          count($this->persistentWriteHeaders),
+          PHP\count($this->writeHeaders) +
+          PHP\count($this->persistentWriteHeaders),
         );
         foreach ($this->persistentWriteHeaders as $str_key => $str_value) {
           $infoData .= $this->writeString($str_key);
@@ -516,28 +532,28 @@ class THeaderTransport extends TFramedTransport
       $headerData =
         $this->getVarint($this->protoId_).$this->getVarint($num_headers);
       $header_size =
-        strlen($transformData) + strlen($infoData) + strlen($headerData);
+        Str\length($transformData) + Str\length($infoData) + Str\length($headerData);
       $paddingSize = 4 - ($header_size % 4);
       $header_size += $paddingSize;
 
-      $buf = (string) pack('nn', self::HEADER_MAGIC, $this->flags_);
-      $buf .= (string) pack('Nn', $this->seqId_, $header_size / 4);
+      $buf = (string) PHP\pack('nn', self::HEADER_MAGIC, $this->flags_);
+      $buf .= (string) PHP\pack('Nn', $this->seqId_, $header_size / 4);
 
       $buf .= $headerData.$transformData;
       $buf .= $infoData;
 
       // Pad out the header with 0x00
       for ($i = 0; $i < $paddingSize; $i++) {
-        $buf .= (string) pack('C', '\0');
+        $buf .= (string) PHP\pack('C', '\0');
       }
 
       // Append the data
       $buf .= $out;
 
       // Prepend the size.
-      $buf = (string) pack('N', strlen($buf)).$buf;
+      $buf = (string) PHP\pack('N', Str\length($buf)).$buf;
     } else if ($this->clientType_ === self::FRAMED_DEPRECATED) {
-      $buf = (string) pack('N', strlen($out));
+      $buf = (string) PHP\pack('N', Str\length($out));
       $buf .= $out;
     } else if ($this->clientType_ === self::UNFRAMED_DEPRECATED) {
       $buf = $out;
@@ -553,7 +569,7 @@ class THeaderTransport extends TFramedTransport
       );
     }
 
-    if (strlen($buf) > self::MAX_FRAME_SIZE) {
+    if (Str\length($buf) > self::MAX_FRAME_SIZE) {
       throw new TTransportException(
         'Attempting to send oversize frame',
         TTransportException::INVALID_FRAME_SIZE,

--- a/thrift/lib/hack/src/transport/THeaderTransportFactory.php
+++ b/thrift/lib/hack/src/transport/THeaderTransportFactory.php
@@ -1,21 +1,27 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 class THeaderTransportFactory extends TTransportFactory {
   /**
    * @static
    * @param TTransport $transport
    * @return TTransport
    */
+  <<__Override>>
   public function getTransport(TTransport $transport): THeaderTransport {
     $p = Vector {
       THeaderTransport::HEADER_CLIENT_TYPE,

--- a/thrift/lib/hack/src/transport/THttpClient.php
+++ b/thrift/lib/hack/src/transport/THttpClient.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * HTTP client for Thrift
  *
@@ -57,7 +62,7 @@ class THttpClient extends TTransport implements IThriftRemoteConn {
    *
    * @var resource
    */
-  protected string $data_;
+  protected /*Sometimes assigned bool*/ WRONG_TYPE_HH_FIXME<string> $data_;
 
   /**
    * Error message
@@ -92,7 +97,7 @@ class THttpClient extends TTransport implements IThriftRemoteConn {
    *
    * @var mixed
    */
-  protected (function(string): bool) $debugHandler_;
+  protected Predicate<string> $debugHandler_;
 
   /**
    * Specifies the maximum number of bytes to read
@@ -118,9 +123,9 @@ class THttpClient extends TTransport implements IThriftRemoteConn {
     int $port = 80,
     string $uri = '',
     string $scheme = 'http',
-    ?(function(string): bool) $debugHandler = null,
+    ?Predicate<string> $debugHandler = null,
   ) {
-    if ($uri && ($uri[0] != '/')) {
+    if ($uri !== '' && ($uri[0] != '/')) {
       $uri = '/'.$uri;
     }
     $this->scheme_ = $scheme;
@@ -132,7 +137,7 @@ class THttpClient extends TTransport implements IThriftRemoteConn {
     $this->errstr_ = '';
     $this->timeout_ = null;
     $this->custom_headers_ = null;
-    $this->debugHandler_ = $debugHandler ?: fun('error_log');
+    $this->debugHandler_ = $debugHandler ?: fun('HH\\Lib\\PHP\\error_log');
   }
 
   /**
@@ -217,6 +222,7 @@ class THttpClient extends TTransport implements IThriftRemoteConn {
    *
    * @return boolean true if open
    */
+  <<__Override>>
   public function isOpen(): bool {
     return true;
   }
@@ -226,11 +232,13 @@ class THttpClient extends TTransport implements IThriftRemoteConn {
    *
    * @throws TTransportException if cannot open
    */
+  <<__Override>>
   public function open(): void {}
 
   /**
    * Close the transport.
    */
+  <<__Override>>
   public function close(): void {
     $this->data_ = '';
   }
@@ -242,17 +250,18 @@ class THttpClient extends TTransport implements IThriftRemoteConn {
    * @return string The data that has been read
    * @throws TTransportException if cannot read any more data
    */
+  <<__Override>>
   public function read(int $len): string {
     if ($this->maxReadChunkSize_ !== null) {
-      $len = min($len, $this->maxReadChunkSize_);
+      $len = Math\minva($len, $this->maxReadChunkSize_);
     }
 
-    if (strlen($this->data_) < $len) {
+    if (Str\length($this->data_) < $len) {
       $data = $this->data_;
       $this->data_ = '';
     } else {
-      $data = substr($this->data_, 0, $len);
-      $this->data_ = substr($this->data_, $len);
+      $data = PHP\substr($this->data_, 0, $len);
+      $this->data_ = PHP\substr($this->data_, $len);
     }
 
     if ($data === false || $data === '') {
@@ -279,6 +288,7 @@ class THttpClient extends TTransport implements IThriftRemoteConn {
    * @param string $buf  The data to write
    * @throws TTransportException if writing fails
    */
+  <<__Override>>
   public function write(string $buf): void {
     $this->buf_ .= $buf;
   }
@@ -288,50 +298,51 @@ class THttpClient extends TTransport implements IThriftRemoteConn {
    *
    * @throws TTransportException if a writing error occurs
    */
+  <<__Override>>
   public function flush(): void {
     $host = $this->host_.':'.$this->port_;
     $user_agent = 'PHP/THttpClient';
-    /* HH_FIXME[2050] We know $_SERVER exists, even if Hack doesn't */
-    $script = (string) urlencode(basename($_SERVER['SCRIPT_FILENAME']));
-    if ($script) {
+    $script = (string) PHP\urlencode(PHP\basename(PHPism_FIXME::coerceToString(GlobalSERVER::idx('SCRIPT_FILENAME'))));
+    if ($script !== '') {
       $user_agent .= ' ('.$script.')';
     }
 
-    $curl = curl_init($this->scheme_.'://'.$host.$this->uri_);
+    $curl = PHP\curl_init($this->scheme_.'://'.$host.$this->uri_);
 
-    $headers = array(
+    $headers = varray[
       'Host: '.$host,
       'Accept: application/x-thrift',
       'User-Agent: '.$user_agent,
       'Content-Type: application/x-thrift',
-      'Content-Length: '.(string) strlen($this->buf_),
-    );
+      'Content-Length: '.(string) Str\length($this->buf_),
+    ];
 
     if ($this->custom_headers_ !== null) {
       foreach ($this->custom_headers_ as $header => $value) {
         $headers[] = $header.': '.$value;
       }
     }
-    curl_setopt($curl, CURLOPT_PROXY, '');
-    curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-    curl_setopt($curl, CURLOPT_POST, true);
-    curl_setopt($curl, CURLOPT_MAXREDIRS, 1);
-    curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
-    curl_setopt($curl, CURLOPT_POSTFIELDS, $this->buf_);
-    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($curl, CURLOPT_BINARYTRANSFER, true);
-    curl_setopt($curl, CURLOPT_TIMEOUT, $this->timeout_);
+    PHP\curl_setopt($curl, CURLOPT_PROXY, '');
+    PHP\curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+    PHP\curl_setopt($curl, CURLOPT_POST, true);
+    PHP\curl_setopt($curl, CURLOPT_MAXREDIRS, 1);
+    PHP\curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+    PHP\curl_setopt($curl, CURLOPT_POSTFIELDS, $this->buf_);
+    PHP\curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+    PHP\curl_setopt($curl, CURLOPT_BINARYTRANSFER, true);
+    PHP\curl_setopt($curl, CURLOPT_TIMEOUT, $this->timeout_);
     if ($this->caInfo_ !== null) {
-      curl_setopt($curl, CURLOPT_CAINFO, $this->caInfo_);
+      PHP\curl_setopt($curl, CURLOPT_CAINFO, $this->caInfo_);
     }
 
     $this->buf_ = '';
-    $this->data_ = curl_exec($curl);
+    $this->data_ = PHP\curl_exec($curl);
 
-    $this->errstr_ = curl_error($curl);
-    curl_close($curl);
+    $this->errstr_ = PHP\curl_error($curl);
+    PHP\curl_close($curl);
 
     // Connect failed?
+    /* HH_FIXME[4118] trivial equality check */
     if ($this->data_ === false) {
       $error = 'THttpClient: Could not connect to '.$host.$this->uri_;
       throw new TTransportException($error, TTransportException::NOT_OPEN);

--- a/thrift/lib/hack/src/transport/THttpClientPool.php
+++ b/thrift/lib/hack/src/transport/THttpClientPool.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /** Inherits from THttpClient */
 
 /**
@@ -24,7 +29,7 @@ class THttpClientPool extends THttpClient {
    * Servers belonging to this pool. Array of associative arrays with 'host' and
    * 'port' keys.
    */
-  protected array<(string, int)> $servers_ = array();
+  protected varray<(string, int)> $servers_ = varray[];
 
   /**
    * Try hosts in order? or randomized?
@@ -50,11 +55,11 @@ class THttpClientPool extends THttpClient {
    * @param string $scheme  http or https
    */
   public function __construct(
-    KeyedContainer<mixed, string> $hosts,
-    KeyedContainer<mixed, int> $ports,
+    KeyedContainer<arraykey, string> $hosts,
+    KeyedContainer<arraykey, int> $ports,
     string $uri = '',
     string $scheme = 'http',
-    ?(function(string): bool) $debugHandler = null,
+    ?Predicate<string> $debugHandler = null,
   ) {
     parent::__construct('', 0, $uri, $scheme, $debugHandler);
 
@@ -97,9 +102,12 @@ class THttpClientPool extends THttpClient {
    * Trys to open a connection and send the actual HTTP request to the first
    * available server in the pool.
    */
+  <<__Override>>
   public function flush(): void {
     if ($this->randomize_) {
-      shuffle($this->servers_);
+      $__servers = $this->servers_;
+      PHP\shuffle(inout $__servers);
+      $this->servers_ = $__servers;
     }
 
     foreach ($this->servers_ as $server) {
@@ -113,7 +121,7 @@ class THttpClientPool extends THttpClient {
           return;
         } catch (TTransportException $e) {
           if ($this->debug_) {
-            call_user_func($this->debugHandler_, $e->getMessage());
+            ($this->debugHandler_)($e->getMessage());
           }
           --$j;
         }

--- a/thrift/lib/hack/src/transport/TNonBlockingSocketNoThrow.php
+++ b/thrift/lib/hack/src/transport/TNonBlockingSocketNoThrow.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Wrapper class over TNonBlockingSocket that suppresses
  * the exception "operation in progress 115" when the open()
@@ -17,13 +22,14 @@
  * handle properly this event. Ie. TFramedTransport.
  */
 class TNonBlockingSocketNoThrow extends TNonBlockingSocket {
+  <<__Override>>
   public function open(): void {
     try {
       parent::open();
     } catch (Exception $e) {
       $op_in_progress =
-        (strpos($e->getMessage(), "socket_connect error") !== false) &&
-        (strpos($e->getMessage(), "[115]") !== false);
+        (PHP\strpos($e->getMessage(), "socket_connect error") !== false) &&
+        (PHP\strpos($e->getMessage(), "[115]") !== false);
       if (!$op_in_progress) {
         throw $e;
       }

--- a/thrift/lib/hack/src/transport/TNullTransport.php
+++ b/thrift/lib/hack/src/transport/TNullTransport.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Transport that only accepts writes and ignores them.
  * This is useful for measuring the serialized size of structures.
@@ -18,18 +23,23 @@
  */
 class TNullTransport extends TTransport {
 
+  <<__Override>>
   public function isOpen(): bool {
     return true;
   }
 
+  <<__Override>>
   public function open(): void {}
 
+  <<__Override>>
   public function close(): void {}
 
+  <<__Override>>
   public function read(int $len): string {
     throw new TTransportException("Can't read from TNullTransport.");
   }
 
+  <<__Override>>
   public function write(string $buf): void {}
 
 }

--- a/thrift/lib/hack/src/transport/TServerSocket.php
+++ b/thrift/lib/hack/src/transport/TServerSocket.php
@@ -1,15 +1,20 @@
-<?hh
+<?hh // partial
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Server socket class
  */

--- a/thrift/lib/hack/src/transport/TTransport.php
+++ b/thrift/lib/hack/src/transport/TTransport.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Base interface for a transport agent.
  *
@@ -60,8 +65,7 @@ abstract class TTransport {
     // return $this->read($len);
 
     $data = '';
-    $got = 0;
-    while (($got = strlen($data)) < $len) {
+    for ($got = Str\length($data); $got < $len; $got = Str\length($data)) {
       $data .= $this->read($len - $got);
     }
     return $data;

--- a/thrift/lib/hack/src/transport/TTransportException.php
+++ b/thrift/lib/hack/src/transport/TTransportException.php
@@ -1,15 +1,20 @@
 <?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Transport exceptions
  *
@@ -22,7 +27,7 @@
  * @param mixed  $code Code (integer) or values (array)
  * @param string $shortMessage (string)
  */
-class TTransportException extends TException {
+final class TTransportException extends TException {
 
   const UNKNOWN = 0;
   const NOT_OPEN = 1;

--- a/thrift/lib/hack/src/transport/TTransportFactory.php
+++ b/thrift/lib/hack/src/transport/TTransportFactory.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 class TTransportFactory {
   /**
    * @static

--- a/thrift/lib/hack/src/transport/TTransportStatus.php
+++ b/thrift/lib/hack/src/transport/TTransportStatus.php
@@ -1,15 +1,20 @@
-<?hh // strict
+<?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  *  Determine (as best as possible) whether the transport can preform
  *  non-blocking read and write operations.

--- a/thrift/lib/hack/src/transport/TTransportSupportsHeaders.php
+++ b/thrift/lib/hack/src/transport/TTransportSupportsHeaders.php
@@ -1,21 +1,24 @@
 <?hh
 
-/**
-* Copyright (c) 2006- Facebook
-* Distributed under the Thrift Software License
-*
-* See accompanying file LICENSE or visit the Thrift site at:
-* http://developers.facebook.com/thrift/
-*
-* @package thrift.transport
-*/
-
+/*
+ * Copyright 2006-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 interface TTransportSupportsHeaders {
-  public function setHeader(string $str_key, @string $str_value): this;
+  public function setHeader(string $str_key, string $str_value): this;
   public function setPersistentHeader(
-    string $str_key,
-    @string $str_value,
-  ): this;
+    string $str_key, string $str_value): this;
   public function getWriteHeaders(): KeyedContainer<string, string>;
   public function getPersistentWriteHeaders(): KeyedContainer<string, string>;
   public function getHeaders(): KeyedContainer<string, string>;


### PR DESCRIPTION
Summary:
The hack files were out of sync, the source of truth for those files are
outside of this repository.

I ran the `ImportThriftLibFromWWW` script which only works for Hack files, I
updated it to remove the transpilation step which was supposed to update the
php files (it doesn't work anymore since it can't find the `h2tp` transpiler)
and AFAIK we don't use php anymore.

I also ran `arc lint` to update the license headers to the correct format.

Differential Revision: D16186893

