### PR TITLE
bugfix: compile errors due to 'fmt'

### DIFF
--- a/thrift/lib/cpp/protocol/TProtocolException.cpp
+++ b/thrift/lib/cpp/protocol/TProtocolException.cpp
@@ -17,6 +17,7 @@
 #include <thrift/lib/cpp/protocol/TProtocolException.h>
 
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 
 namespace apache {
 namespace thrift {

--- a/thrift/lib/cpp/util/THttpParser.cpp
+++ b/thrift/lib/cpp/util/THttpParser.cpp
@@ -19,6 +19,7 @@
 #include <thrift/lib/cpp/transport/TTransportException.h>
 
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 #include <folly/String.h>
 
 #include <cstdlib>


### PR DESCRIPTION
fbthrift did not compile due to missing includes.