### PR TITLE
cpp2: fix SO_REUSEPORT usage in ThriftServer

### DIFF
--- a/thrift/lib/cpp2/server/ThriftServer.cpp
+++ b/thrift/lib/cpp2/server/ThriftServer.cpp
@@ -276,7 +276,7 @@ void ThriftServer::setup() {
       ServerBootstrap::socketConfig.acceptBacklog = getListenBacklog();
       ServerBootstrap::socketConfig.maxNumPendingConnectionsPerWorker =
           getMaxNumPendingConnectionsPerWorker();
-      if (reusePort_) {
+      if (reusePort_.value_or(false)) {
         ServerBootstrap::setReusePort(true);
       }
       if (enableTFO_) {


### PR DESCRIPTION
Set **SO_REUSEPORT** only if folly::Optional *reusePort_* is set and its value is true

Signed-off-by: Anton Tiurin <noxiouz@yandex.ru>