### PR TITLE
Generated fields privatized for PHP; add getters/setters

### DIFF
--- a/thrift/compiler/generate/t_php_generator.cc
+++ b/thrift/compiler/generate/t_php_generator.cc
@@ -1266,7 +1266,7 @@ void t_php_generator::_generate_php_struct_definition(
         !(t->is_struct() || t->is_xception())) {
       dval = render_const_value((*m_iter)->get_type(), (*m_iter)->get_value());
     }
-    indent(out) << "private $" << (*m_iter)->get_name() << " = " << dval << ";"
+    indent(out) << "public $" << (*m_iter)->get_name() << " = " << dval << ";"
                 << endl;
   }
 
@@ -1371,7 +1371,7 @@ void t_php_generator::generate_reflection_getters(ostringstream& out,
                                                    string cap_name) {
 
 
-  out << indent() << "public function " << (type->is_bool() ? "is" : "get") << cap_name << "()" << endl
+  out << indent() << "public function " <<  "get" << cap_name << "()" << endl
       << indent() << "{" << endl;
 
   indent_up();

--- a/thrift/compiler/generate/t_php_generator.cc
+++ b/thrift/compiler/generate/t_php_generator.cc
@@ -1343,10 +1343,7 @@ void t_php_generator::generate_generic_field_getters_setters(std::ostream& out,
   std::ostringstream setter_stream;
 
   // build up the bodies of both the getter and setter at once
-  const vector<t_field*>& fields = tstruct->get_members();
-  vector<t_field*>::const_iterator f_iter;
-  for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
-    t_field* field = *f_iter;
+  for (const auto& field : tstruct->get_members())
     t_type* type = (field->get_type())->get_true_type();
     std::string field_name = field->get_name();
     std::string cap_name = get_cap_name(field_name);

--- a/thrift/compiler/generate/t_php_generator.cc
+++ b/thrift/compiler/generate/t_php_generator.cc
@@ -1343,7 +1343,7 @@ void t_php_generator::generate_generic_field_getters_setters(std::ostream& out,
   std::ostringstream setter_stream;
 
   // build up the bodies of both the getter and setter at once
-  for (const auto& field : tstruct->get_members())
+  for (const auto& field : tstruct->get_members()) {
     t_type* type = (field->get_type())->get_true_type();
     std::string field_name = field->get_name();
     std::string cap_name = get_cap_name(field_name);

--- a/thrift/compiler/generate/t_php_generator.cc
+++ b/thrift/compiler/generate/t_php_generator.cc
@@ -1347,7 +1347,7 @@ void t_php_generator::generate_generic_field_getters_setters(std::ostream& out,
   vector<t_field*>::const_iterator f_iter;
   for (f_iter = fields.begin(); f_iter != fields.end(); ++f_iter) {
     t_field* field = *f_iter;
-    t_type* type = get_true_type(field->get_type());
+    t_type* type = (field->get_type())->get_true_type();
     std::string field_name = field->get_name();
     std::string cap_name = get_cap_name(field_name);
 

--- a/thrift/compiler/generate/t_php_generator.cc
+++ b/thrift/compiler/generate/t_php_generator.cc
@@ -1352,7 +1352,7 @@ void t_php_generator::generate_generic_field_getters_setters(std::ostream& out,
     std::string cap_name = get_cap_name(field_name);
 
     indent_up();
-    generate_reflection_setters(setter_stream, type, field_name, cap_name);
+    generate_reflection_setters(setter_stream, field_name, cap_name);
     generate_reflection_getters(getter_stream, type, field_name, cap_name);
     indent_down();
   }


### PR DESCRIPTION
Solves: https://github.com/facebook/fbthrift/issues/352

Java-style private fields added with accessors/mutators