### PR TITLE
Allow Enum as Frozen HashMap or HashSet key

### DIFF
--- a/thrift/lib/cpp2/frozen/FrozenEnum-inl.h
+++ b/thrift/lib/cpp2/frozen/FrozenEnum-inl.h
@@ -60,6 +60,10 @@ struct EnumLayout : public PackedIntegerLayout<Underlying> {
     thaw(self, v);
     return v;
   }
+
+  static size_t hash(const T& v) {
+    return std::hash<T>()(v);
+  }
 };
 } // namespace detail
 

--- a/thrift/lib/cpp2/frozen/test/Example.thrift
+++ b/thrift/lib/cpp2/frozen/test/Example.thrift
@@ -118,3 +118,11 @@ struct VectorTest {
        aHashMap;
   6: list<i32> (cpp.template = "folly::fbvector") fbVector;
 }
+
+struct EnumAsKeyTest {
+  1: set<Gender> (cpp.template = 'std::unordered_set') enumSet,
+  2: map<Gender, i32> (cpp.template = 'std::unordered_map') enumMap,
+  3: set<Helper.Animal> (cpp.template = 'std::unordered_set') outsideEnumSet,
+  4: map<Helper.Animal, i32>
+      (cpp.template = 'std::unordered_map') outsideEnumMap,
+}

--- a/thrift/lib/cpp2/frozen/test/FrozenTest.cpp
+++ b/thrift/lib/cpp2/frozen/test/FrozenTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
 
 #include <thrift/lib/cpp2/frozen/FrozenUtil.h>
@@ -26,6 +27,7 @@ using namespace apache::thrift;
 using namespace apache::thrift::frozen;
 using namespace apache::thrift::test;
 using namespace apache::thrift::util;
+using namespace testing;
 
 template <class T>
 std::string toString(const T& x) {
@@ -346,6 +348,20 @@ TEST(Frozen, Enum) {
   she.gender = Gender::Female;
   EXPECT_EQ(he, freeze(he).thaw());
   EXPECT_EQ(she, freeze(she).thaw());
+}
+
+TEST(Frozen, EnumAsKey) {
+  EnumAsKeyTest thriftObj;
+  thriftObj.enumSet.insert(Gender::Male);
+  thriftObj.enumMap.emplace(Gender::Female, 1219);
+  thriftObj.outsideEnumSet.insert(Animal::DOG);
+  thriftObj.outsideEnumMap.emplace(Animal::CAT, 7779);
+
+  auto frozenObj = freeze(thriftObj);
+  EXPECT_THAT(frozenObj.enumSet(), Contains(Gender::Male));
+  EXPECT_THAT(frozenObj.outsideEnumSet(), Contains(Animal::DOG));
+  EXPECT_EQ(frozenObj.enumMap().at(Gender::Female), 1219);
+  EXPECT_EQ(frozenObj.outsideEnumMap().at(Animal::CAT), 7779);
 }
 
 template <class T>

--- a/thrift/lib/cpp2/frozen/test/Helper.thrift
+++ b/thrift/lib/cpp2/frozen/test/Helper.thrift
@@ -19,3 +19,8 @@ struct Ratio {
   1 : i32 num,
   2 : i32 denom,
 }
+
+enum Animal {
+  DOG = 1,
+  CAT = 2,
+}


### PR DESCRIPTION
Summary:
This is a long existing issue. When Enum is used as the HashMap or HashSet key, compiler error will happen like this:
    error: reference to type 'const int' could not bind to an lvalue of type 'const typename SelfKey<MetadataSource>::KeyType'

The reason is `EnumLayout` hasn't implement the `hash` function, so the `hash` function of `PackedIntegerLayout` will be used, and it only takes `const int` as key type, not the enum.

The fix is simple, just implement hash function for `EnumLayout`.

Reviewed By: yfeldblum, ddrcoder

Differential Revision: D17223958

