### PR TITLE
Allow Frozen to recognize std::deque

### DIFF
--- a/thrift/lib/cpp2/frozen/FrozenRange-inl.h
+++ b/thrift/lib/cpp2/frozen/FrozenRange-inl.h
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <deque>
+
 namespace apache {
 namespace thrift {
 namespace frozen {
@@ -368,4 +370,5 @@ struct Layout<T, typename std::enable_if<IsList<T>::value>::type>
 } // namespace apache
 
 THRIFT_DECLARE_TRAIT_TEMPLATE(IsList, std::vector)
+THRIFT_DECLARE_TRAIT_TEMPLATE(IsList, std::deque)
 THRIFT_DECLARE_TRAIT_TEMPLATE(IsList, folly::fbvector)


### PR DESCRIPTION
Summary: [Thrift] Allow Frozen to recognize `std::deque`.

Reviewed By: yfeldblum

Differential Revision: D17193353

