### PR TITLE
Bug fix to enable re-generate on thrift file change

### DIFF
--- a/ThriftLibrary.cmake
+++ b/ThriftLibrary.cmake
@@ -255,7 +255,9 @@ macro(thrift_generate
       -o ${output_path}
       ${thrift_include_directories}
       "${file_path}/${file_name}.thrift"
-    DEPENDS ${THRIFT1}
+    DEPENDS 
+      ${THRIFT1}
+      "${file_path}/${file_name}.thrift"
     COMMENT "Generating ${file_name} files. Output: ${output_path}"
   )
   add_custom_target(


### PR DESCRIPTION
The current cmake macros does not re-generate code when the thrift file is changed. This is because the cmake_custom_command only lists thrift1 as dependency. By adding the thrift file to the dependencies list, we can force cmake re-generates code when the file is changed.

Tested on my custom code.