### PR TITLE
Java: add setClientType() in THeaderTransport

### DIFF
--- a/thrift/lib/java/src/main/java/com/facebook/thrift/transport/THeaderTransport.java
+++ b/thrift/lib/java/src/main/java/com/facebook/thrift/transport/THeaderTransport.java
@@ -171,6 +171,20 @@ public class THeaderTransport extends TFramedTransport {
   }
 
   /**
+   * Returns the current client type we are reading/writing
+   *
+   * @return client type
+   */
+   public ClientTypes getClientType() {
+       return this.clientType;
+   }
+
+   /** Sets client type we are writing */
+   public void setClientType(ClientTypes clientType) {
+       this.clientType = clientType;
+   }
+
+  /**
    * Sets the internal buffer size for zlib transform This will work with any value (except 0), but
    * this is provided as an optimization knob.
    *


### PR DESCRIPTION
THeaderTransport can sniff the client type on reading the request, then response in theader or tframed as the clientType field says. But in some cases (like TNonBlockingServer) there are different inputTHeaderTransportFactory and outputTHeaderTransportFactory which produces different THeaderTransport objects, the output side can not easily get the clientType which sniffed by the input THeaderTransport object.

If there's a getter/setter for clientType, then we can set the sniffed clientType from the input THeaderTransport object to the output THeaderTransport object. It would be nice when we still have some legacy tframed transport deployment.

It shows that there has a setClientType / getClientType in the C++ lib (https://github.com/facebook/fbthrift/blob/86ffa61e2a7c51f1fa33aa2d3908d9d5820d6cf6/thrift/lib/cpp/transport/THeader.h#L101) , maybe it would be nice to have the same methods in the Java lib?

Thank you a lot.