### PR TITLE
Add support of Go1.13 error handling for transport exception

### DIFF
--- a/thrift/lib/go/thrift/transport_exception.go
+++ b/thrift/lib/go/thrift/transport_exception.go
@@ -62,6 +62,11 @@ func (p *transportException) Error() string {
 	return p.err.Error()
 }
 
+// Unwrap is used for errors.Unwrap.
+func (p *transportException) Unwrap() error {
+	return p.err
+}
+
 func (p *transportException) Err() error {
 	return p.err
 }

--- a/thrift/lib/go/thrift/transport_exception_test.go
+++ b/thrift/lib/go/thrift/transport_exception_test.go
@@ -17,6 +17,7 @@
 package thrift
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -53,5 +54,16 @@ func TestExceptionEOF(t *testing.T) {
 
 	if exception.TypeID() != END_OF_FILE {
 		t.Fatalf("TypeID was not END_OF_FILE: expected %v, got %v", END_OF_FILE, exception.TypeID())
+	}
+}
+
+func TestTransportExceptionUnwrap(t *testing.T) {
+	origErr := errors.New("unit-test")
+	exception := &transportException{
+		err: origErr,
+	}
+	if !errors.Is(exception, origErr) {
+		t.Fatalf("exception %T:%v wasn't unwrapped to %T:%v",
+			exception, exception, origErr, origErr)
 	}
 }


### PR DESCRIPTION
Summary: Sometimes it is required to know when it was unable to establish a Thrift connection due to invalid certificate. And to be able to check the error using standard Go>=1.13 tools we add an method `Unwrap()` here.

Reviewed By: dlespiau

Differential Revision: D23447622

