### PR TITLE
Optimize whitespace char lookup in skipWhitespace

### DIFF
--- a/thrift/lib/py/protocol/TSimpleJSONProtocol.py
+++ b/thrift/lib/py/protocol/TSimpleJSONProtocol.py
@@ -75,6 +75,13 @@ ESCAPE_CHAR_VALS = [b'"', b'\\', b'\b', b'\f', b'\n', b'\r', b'\t']
 
 NUMERIC_CHAR = b'+-.0123456789Ee'
 
+WHITESPACE_CHARS = {
+    JSON_NEW_LINE,
+    TAB,
+    JSON_CARRIAGE_RETURN,
+    JSON_SPACE,
+}
+
 def hexChar(x):
     x &= 0x0f
     return hex(x)[2:]
@@ -336,10 +343,7 @@ class TSimpleJSONProtocolBase(TProtocolBase, object):
         skipped = 0
         while True:
             ch = self.reader.peek()
-            if ch not in (JSON_NEW_LINE,
-                          TAB,
-                          JSON_CARRIAGE_RETURN,
-                          JSON_SPACE):
+            if ch not in WHITESPACE_CHARS:
                 break
             self.reader.read()
             skipped += 1


### PR DESCRIPTION
Summary:
A tiny improvement to the `skipWhitespace` function.

Previously, it would construct a `tuple` per char and then perform a linear lookup. Now, I have changed the repetitive `tuple` construction into a one-time `set` construction.

Over 100000000 spaces (worst cast lookup, because space is last in the tuple):

* Not repeating the `tuple` construction gave a 2x speedup
* Changing the `tuple` to a `set` gave a 3x speedup

Reviewed By: nanshu

Differential Revision: D24776910

