### PR TITLE
bugfix: set seq id when write begin by server

### DIFF
--- a/thrift/lib/go/thrift/header_protocol.go
+++ b/thrift/lib/go/thrift/header_protocol.go
@@ -81,11 +81,9 @@ func (p *HeaderProtocol) ResetProtocol() error {
 func (p *HeaderProtocol) WriteMessageBegin(name string, typeId MessageType, seqid int32) error {
 	p.ResetProtocol()
 
-	// The conditions here only match on the Go client side.
-	// If we are a client, set header seq id same as msg id
-	if typeId == CALL || typeId == ONEWAY {
-		p.trans.SetSeqID(uint32(seqid))
-	}
+	// Set header seq id same as msg id
+	p.trans.SetSeqID(uint32(seqid))
+
 	return p.Protocol.WriteMessageBegin(name, typeId, seqid)
 }
 


### PR DESCRIPTION
We use `ConcurrentServer` and found a bug for concurrent RPC calls in one connection.

When the concurrent server wants to write a response back to the client, it uses `readSeqID` which may be wrong because of there is a new frame coming and has been read by `ResetProtocol`. 

So the PR wants to `SetSeqId` when write message begin in server side.