### PR TITLE
feat: Replace struct with interface in ClientConn

### DIFF
--- a/thrift/lib/go/thrift/clientconn_test.go
+++ b/thrift/lib/go/thrift/clientconn_test.go
@@ -129,7 +129,7 @@ func TestSendMsgError(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		cc := ClientConn{oproto: testCase.oproto}
+		cc := &clientConn{oproto: testCase.oproto}
 
 		if err := cc.SendMsg("foobar", testCase.request, CALL); err.Error() != testCase.expected.Error() {
 			t.Errorf("#%d: expected call to SendMsg to return \"%+v\"; got \"%+v\"", i, testCase.expected, err)
@@ -177,7 +177,7 @@ func TestRecvMsgError(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		cc := ClientConn{iproto: testCase.iproto}
+		cc := &clientConn{iproto: testCase.iproto}
 
 		if err := cc.RecvMsg("foobar", testCase.response); err.Error() != testCase.expected.Error() {
 			t.Errorf("#%d: expected call to RecvMsg to return \"%+v\"; got \"%+v\"", i, testCase.expected, err)


### PR DESCRIPTION
We are creating our own multiplexing client for thrift. And we found that the gen-go code using `thrift.ClientConn` which is not supported to write another packet when reading(multiplexing).  So we want to rewrite the `thrift.ClientConn`.

Replace struct with interface from ClientConn will not make any other code broken but make it could have more flexibility and scalability.