### PR TITLE
fix: check seqid in header with payload seqid

### DIFF
--- a/thrift/lib/go/thrift/header_protocol.go
+++ b/thrift/lib/go/thrift/header_protocol.go
@@ -106,6 +106,9 @@ func (p *HeaderProtocol) ReadMessageBegin() (name string, typeId MessageType, se
 	}
 
 	name, typeId, seqid, err = p.Protocol.ReadMessageBegin()
+	if p.trans.clientType != HeaderClientType {
+		return
+	}
 	hseqid := p.trans.SeqID()
 	if uint32(seqid) != hseqid {
 		return name, EXCEPTION, seqid, NewTransportException(


### PR DESCRIPTION
As mentioned in TODO comment, we should check the seqid in header to validate the frame.