### PR TITLE
HTE lint-ignore message cleanup at fbcode

### DIFF
--- a/thrift/lib/cpp2/test/OptionalFieldTest.cpp
+++ b/thrift/lib/cpp2/test/OptionalFieldTest.cpp
@@ -150,7 +150,7 @@ TEST(RequiredFieldRefTest, HeterogeneousComparisons) {
 struct Tag {};
 
 namespace std {
-// @lint-ignore HOWTOEVEN CLANGTIDY
+// @lint-ignore CLANGTIDY
 template <>
 struct hash<Tag> {
   explicit hash(size_t i) : i(i) {}
@@ -162,7 +162,7 @@ struct hash<Tag> {
 } // namespace std
 
 namespace folly {
-// @lint-ignore HOWTOEVEN CLANGTIDY
+// @lint-ignore CLANGTIDY
 template <>
 struct hasher<Tag> {
   explicit hasher(size_t i) : i(i) {}


### PR DESCRIPTION
Summary: The diff removes HOWTOEVEN from all lint-ignore messages at fbcode

Reviewed By: dkgi

Differential Revision: D26278830

