### PR TITLE
Remove constness of frozen range iterator value type

### DIFF
--- a/thrift/lib/cpp2/frozen/FrozenRange-inl.h
+++ b/thrift/lib/cpp2/frozen/FrozenRange-inl.h
@@ -240,9 +240,9 @@ struct ArrayLayout : public LayoutBase {
     class Iterator {
      public:
       using difference_type = ptrdiff_t;
-      using value_type = const ItemView;
-      using pointer = value_type*;
-      using reference = value_type&;
+      using value_type = ItemView;
+      using pointer = const value_type*;
+      using reference = const value_type&;
       using iterator_category = std::random_access_iterator_tag;
 
       Iterator() {}

--- a/thrift/lib/cpp2/frozen/test/FrozenRangeTest.cpp
+++ b/thrift/lib/cpp2/frozen/test/FrozenRangeTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <numeric>
+
 #include <folly/portability/GTest.h>
 
 #include <thrift/lib/cpp2/frozen/FrozenUtil.h>
@@ -51,6 +53,9 @@ TYPED_TEST_P(FrozenRange, Iterators) {
   EXPECT_EQ(*it--, 13);
   EXPECT_EQ(*it--, 12);
   EXPECT_EQ(*--it, 10);
+  std::adjacent_difference(fv.begin(), fv.end(), v.begin());
+  TypeParam ref{10, 1, 1, 1};
+  EXPECT_EQ(v, ref);
 }
 
 TYPED_TEST_P(FrozenRange, IteratorComparisons) {


### PR DESCRIPTION
In the frozen range iterator, pointers and references must be
const, but the `value_type` itself must not. A const `value_type`
prevents algorithms like e.g. `adjacent_difference` from working
correctly, as they require a mutable `value_type` instance to
store temporary values.

Added a test case that didn't previously compile.