### PR TITLE
Add missing dependency on RocketUpgrade headers to thriftcpp2 target

### DIFF
--- a/thrift/lib/cpp2/CMakeLists.txt
+++ b/thrift/lib/cpp2/CMakeLists.txt
@@ -208,6 +208,7 @@ add_dependencies(
   thriftcpp2
   rpcmetadata
   thriftmetadata
+  RocketUpgrade-cpp2-target
 )
 target_link_libraries(
   thriftcpp2


### PR DESCRIPTION
One source file in this target, async/HeaderClientChannel.cpp,
depends on the generated header RocketUpgradeAsyncClient.h, so it
needs to depend on the target that generates this header.

This causes a build error with samurai due to an incorrect build
order, and can be reproduced with ninja as well by building
thrift/lib/cpp2/CMakeFiles/thriftcpp2.dir/async/HeaderClientChannel.cpp.o
directly with an empty .ninja_deps.