### PR TITLE
Fix dependency and cmake install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set(INCLUDE_INSTALL_DIR include CACHE STRING
     "The subdirectory where include files should be installed")
 set(LIB_INSTALL_DIR lib CACHE STRING
     "The subdirectory where libraries should be installed")
-set(CMAKE_INSTALL_DIR lib/cmake/fbthrift CACHE STRING
+set(CMAKE_INSTALL_DIR share/fbthrift CACHE STRING
     "The subdirectory where CMake package config files should be installed")
 
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}")

--- a/thrift/cmake/FBThriftConfig.cmake.in
+++ b/thrift/cmake/FBThriftConfig.cmake.in
@@ -15,6 +15,9 @@
 
 include(CMakeFindDependencyMacro)
 
+find_dependency(folly)
+find_dependency(fmt)
+
 # Save the PACKAGE_PREFIX_DIR in a separate variable.  find_dependency() calls
 # below can replace PACKAGE_PREFIX_DIR with the prefix of the dependency that
 # was searched for.


### PR DESCRIPTION
- Currently, `CMAKE_INSTALL_DIR ` was set as `lib/cmake/fbthrift ` in CMakeLists.txt, but in fact, these *Config.cmake and *Target.cmake files were installed to `share/fbthrift` in vcpkg. In usage, it will build failed with the following errors:

```
CMake Error at /PATH/vcpkg/installed/x64-linux/share/fbthrift/FBThriftConfig.cmake:24 (message):
  File or directory
  /PATH/vcpkg/installed/x64-linux/lib/cmake/fbthrift
  referenced by variable FBTHRIFT_CMAKE_DIR does not exist !
```
- In `FBThriftConfig.cmake.in` file. there is no dependency for `folly `and `fmt`, which causes that `fbthrift `cannot be found successfully.

```
CMake Error at /home/code/vcpkg/scripts/buildsystems/vcpkg.cmake:537 (_add_executable):
  Target "ImageProcessingTests" links to target "Folly::folly" but the target
  was not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
Call Stack (most recent call first):
  CMakeLists.txt:6 (add_executable)

CMake Error at /home/code/vcpkg/scripts/buildsystems/vcpkg.cmake:537 (_add_executable):
  Target "ImageProcessingTests" links to target "fmt::fmt" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
Call Stack (most recent call first):
  CMakeLists.txt:6 (add_executable)
```
Related issue: https://github.com/microsoft/vcpkg/issues/18249

Related PR:  https://github.com/microsoft/vcpkg/pull/18264