### PR TITLE
Use include path relative to local directory

### DIFF
--- a/thrift/lib/thrift/annotation/cpp.thrift
+++ b/thrift/lib/thrift/annotation/cpp.thrift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-include "thrift/lib/thrift/annotation/scope.thrift"
+include "scope.thrift"
 
 namespace cpp2 apache.thrift.annotation
 namespace py3 thrift.lib.thrift.annotation


### PR DESCRIPTION
Building Open/R fails with the absolute path, it makes assumptions about the way include paths are setup