### PR TITLE
Remove non used header from perf/cpp2 bench

### DIFF
--- a/thrift/perf/cpp2/server/BenchmarkHandler.h
+++ b/thrift/perf/cpp2/server/BenchmarkHandler.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <folly/system/ThreadName.h>
 #include <thrift/perf/cpp2/if/gen-cpp2/StreamBenchmark.h>
 #include <thrift/perf/cpp2/util/QPSStats.h>
 


### PR DESCRIPTION
I see folly/system/ThreadName.h  is not being used (their functions are used to identify threads and I don't see any handling thread mechanism here) so it will be better just remove it.