### PR TITLE
Reserve the memory for vector to save cost in `EventBaseHandler.cpp`

### DIFF
--- a/thrift/lib/cpp/EventHandlerBase.h
+++ b/thrift/lib/cpp/EventHandlerBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Reviewed By: yfeldblum

Differential Revision: D34471045

