### PR TITLE
Fix compilation error in thrifty.yy

### DIFF
--- a/thrift/compiler/parse/thrifty.yy
+++ b/thrift/compiler/parse/thrifty.yy
@@ -61,11 +61,7 @@ std::unique_ptr<T> own(T* ptr) {
 }
 
 yy::parser::symbol_type parse_lex(parsing_driver& driver, YYSTYPE*, YYLTYPE*) {
-  auto token = driver.get_lexer().get_next_token();
-  if (token.token() == yy::parser::token::tok_error) {
-    driver.end_parsing();
-  }
-  return token;
+  return driver.get_lexer().get_next_token();
 }
 #define yylex apache::thrift::compiler::parse_lex
 


### PR DESCRIPTION
Work around for error: https://github.com/facebook/fbthrift/issues/491
```
parse/thrifty.yy:65:13: error: ‘struct apache::thrift::compiler::yy::parser::symbol_type’ has no member named ‘token’
```

Introduced in https://github.com/facebook/fbthrift/commit/0ed89d8d06b546c89c60b0dceab0ac36b73f9515