### PR TITLE
thrift/compiler/compiler.cc: Include fstream to fix compatibility with Boost 1.79.0

### DIFF
--- a/thrift/compiler/compiler.cc
+++ b/thrift/compiler/compiler.cc
@@ -32,6 +32,7 @@
 #include <unistd.h>
 #endif
 #include <ctime>
+#include <fstream>
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/split.hpp>


### PR DESCRIPTION
This patch fixes fbthrift build compatibility with Boost 1.79.0. The symptom is the following compiler error:

```
/opt/mcrouter-build/fbthrift/thrift/compiler/compiler.cc: In function ‘bool apache::thrift::compiler::{anonymous}::generate(const apache::thrift::compiler::{anonymous}::gen_params&, apache::thrift::compiler::t_program*, std::set<std::__cxx11::basic_string<char> >&)’:
/opt/mcrouter-build/fbthrift/thrift/compiler/compiler.cc:331:19: error: aggregate ‘std::ofstream genfile’ has incomplete type and cannot be defined
  331 |     std::ofstream genfile;
      |                   ^~~~~~~
make[2]: *** [thrift/compiler/CMakeFiles/thrift1.dir/build.make:76: thrift/compiler/CMakeFiles/thrift1.dir/compiler.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:253: thrift/compiler/CMakeFiles/thrift1.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```

To reproduce, install the standard fbthrift dependencies, but with Boost 1.79.0 compiled from source, followed by:

```
$ mkdir build && cd build
$ cmake -DCMAKE_BUILD_TYPE=RELEASE CXXFLAGS="-fPIC" ..
$ make -j
```

Adding an include on `fstream` allows for the build to complete successfully.