### PR TITLE
Workaround a gcc issue

### DIFF
--- a/thrift/lib/cpp2/GeneratedCodeHelper.h
+++ b/thrift/lib/cpp2/GeneratedCodeHelper.h
@@ -988,7 +988,7 @@ inline void processViaExecuteRequest(
                oneway =
                    (*untypedMethodMetadata.rpcKind ==
                     RpcKind::SINGLE_REQUEST_NO_RESPONSE),
-               processor,
+               processor = processor,
                executor = std::move(executor),
                &untypedMethodMetadata](bool runInline) mutable {
     if (!runInline) {


### PR DESCRIPTION
Works around the following error when building with gcc:

```
thrift/lib/cpp2/GeneratedCodeHelper.h:991:16: error: ‘processor’ was not declared in this scope
                processor,
                ^~~~~~~~~
```