### PR TITLE
add a `find_package` call for fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,12 +98,13 @@ if (compiler_only OR build_all)
 endif ()
 
 # Find required dependencies for thrift/lib
+find_package(fmt CONFIG REQUIRED)
+
 if(lib_only OR build_all)
   find_package(Gflags REQUIRED)
   find_package(Glog REQUIRED)
   find_package(folly CONFIG REQUIRED)
   find_package(fizz CONFIG REQUIRED)
-  find_package(fmt CONFIG REQUIRED)
   find_package(wangle CONFIG REQUIRED)
   find_package(ZLIB REQUIRED)
   find_package(Zstd REQUIRED)

--- a/thrift/compiler/CMakeLists.txt
+++ b/thrift/compiler/CMakeLists.txt
@@ -70,6 +70,8 @@ target_compile_definitions(
   compiler_base
   PRIVATE -DTHRIFTY_HH="${COMPILER_DIR}/thrifty.hh"
 )
+
+find_package(fmt)
 target_link_libraries(
   compiler_base
   compiler_ast

--- a/thrift/compiler/CMakeLists.txt
+++ b/thrift/compiler/CMakeLists.txt
@@ -71,7 +71,6 @@ target_compile_definitions(
   PRIVATE -DTHRIFTY_HH="${COMPILER_DIR}/thrifty.hh"
 )
 
-find_package(fmt)
 target_link_libraries(
   compiler_base
   compiler_ast


### PR DESCRIPTION
Presently, `cmake` fails with the following error:

```
CMake Error at fbthrift/thrift/compiler/CMakeLists.txt:73 (target_link_libraries):
  Target "compiler_base" links to:

    fmt::fmt

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```

This pull request fixes the error by adding the appropriate `find_package` call.