### PR TITLE
Remove flex from thrift dependencies

### DIFF
--- a/build/fbcode_builder/manifests/fbthrift
+++ b/build/fbcode_builder/manifests/fbthrift
@@ -19,7 +19,6 @@ job_weight_mib = 2048
 
 [dependencies]
 bison
-flex
 folly
 wangle
 fizz


### PR DESCRIPTION
Summary: Thrift no longer depends on flex. Update the fbcode builder manifest accordingly.

Reviewed By: thedavekwon

Differential Revision: D35907980

