### PR TITLE
Fix missing include in `source_location.cc`

### DIFF
--- a/thrift/compiler/source_location.cc
+++ b/thrift/compiler/source_location.cc
@@ -17,6 +17,7 @@
 #include <thrift/compiler/source_location.h>
 
 #include <assert.h>
+#include <errno.h>
 #include <string.h>
 #include <algorithm>
 #include <stdexcept>


### PR DESCRIPTION
This fixes a build failure on macOS 10.15 seen while updating Homebrew's
fbthrift at Homebrew/homebrew-core#101747.