### PR TITLE
Minor Corrections In Thrift Docs

### DIFF
--- a/thrift/doc/cpp/cpp2.md
+++ b/thrift/doc/cpp/cpp2.md
@@ -34,9 +34,9 @@ similar to the older first-generation implementation:
   to prevent large allocations of memory.
 
 * Allows true zero-copy from client to server and back using IOBufs
-  (vs. previous generated code that used std::string for binary type).
+  (vs. previously generated code that used std::string for binary type).
 
-* It's about 4x as fast as NonblockingServer in our loadtests
+* It's about 4x as fast as NonblockingServer in our load tests
   (`perf/cpp`) for small requests. Latency is also much improved
   depending on how parallel processing and out of order responses are
   used.
@@ -102,10 +102,10 @@ Will generate an interface similar to
       ...
     }
 
-So you have three choices of handler type to implement:
+So you have three choices of handler types to implement:
 
 1. `sendResponse(...)` is the synchronous method. It will be read and
-   deserialized in an IO thread, then passed to a pool thread to be
+   deserialized in an IO thread, and then passed to a pool thread to be
    executed. When it returns, `_return` must contain the result, which
    will be passed back to the original IO thread to serialize the
    result and send it on the wire. You can block in this handler as
@@ -137,7 +137,7 @@ So you have three choices of handler type to implement:
    When the future completes, the result will be sent.
 
 You only need to override one of these methods in your handler. They
-will be called in turn until an overriden method is found. If you do
+will be called in turn until an overridden method is found. If you do
 not override any method, you will get a runtime error when the method
 is called.
 
@@ -165,7 +165,7 @@ python framework automatically knows which file changes need to go in.
 * enum class: Enums are now generated with C++11's enum class
   feature.
 
-* Arguments on heap: By default complex arguments are on the heap, so
+* Arguments on heap: By default, complex arguments are on the heap, so
   they can be moved between threads without a copy. To disable this,
   use option `stack_arguments`.
 
@@ -180,9 +180,9 @@ python framework automatically knows which file changes need to go in.
 ### Serialization using IOBufs
 
 An IOBuf is a network chained memory buffer, similar to FreeBSD's
-mbuf, or the linux kernel's sk_buff. They can have the memory
+mbuf, or the Linux kernel's sk_buff. They can have the memory
 internally if small enough, or externally malloced and shared. This is
-opaque to the user, and done mostly for performance reasons, similar
+opaque to the user and done mostly for performance reasons, similar
 to fbstring. The IOBuf header itself can point to a subregion of the
 allocated memory, like a view.
 
@@ -248,9 +248,9 @@ we call writeV with the whole of the queue.
   above.
 
 * The previous thrift ThreadManager used mutexs and condition
-  variables to queue tasks and wake up threads. In practice this
+  variables to queue tasks and wake up threads. In practice, this
   limited the throughput to around 300k qps. We have overhauled
   ThreadManager to use a lockless MPMC queue, as well as adding LIFO
   worker thread semantics. This improved the throughput to just under
-  1M qps. Unfortunately it is still sensitive to tuning for the
+  1M qps. Unfortunately, it is still sensitive to tuning for the
   number of worker and IO threads, due to context switching overhead.

--- a/thrift/doc/cpp/cpp2.md
+++ b/thrift/doc/cpp/cpp2.md
@@ -34,7 +34,7 @@ similar to the older first-generation implementation:
   to prevent large allocations of memory.
 
 * Allows true zero-copy from client to server and back using IOBufs
-  (vs. previously generated code that used std::string for binary type).
+  (vs. previous generated code that used std::string for binary type).
 
 * It's about 4x as fast as NonblockingServer in our load tests
   (`perf/cpp`) for small requests. Latency is also much improved
@@ -102,7 +102,7 @@ Will generate an interface similar to
       ...
     }
 
-So you have three choices of handler types to implement:
+So you have three choices of handler type to implement:
 
 1. `sendResponse(...)` is the synchronous method. It will be read and
    deserialized in an IO thread, and then passed to a pool thread to be

--- a/thrift/doc/internals/header-format.md
+++ b/thrift/doc/internals/header-format.md
@@ -56,7 +56,7 @@ doesn't know about the transform ID, an error MUST be returned as we
 don't know how to transform the data.
 
 Conversely, data in the info headers is ignorable.  This should only
-be things like timestamps, debuging tracing, etc.  Using the header
+be things like timestamps, debugging tracing, etc.  Using the header
 size you should be able to skip this data and read the payload safely
 if you don't know the info ID.
 

--- a/thrift/doc/internals/mstch.md
+++ b/thrift/doc/internals/mstch.md
@@ -131,7 +131,7 @@ about the context.
 
 Lists represent zero or more elements of some other type, and function similar
 to for-each loops in other languages. The body of the loop will be expanded
-once per element in the list, and on each iteration, the context will be
+once per element in the list, and, on each iteration the context will be
 extended using each member of the list. While expanding lists, two boolean keys
 named `first?` and `last?` will be available, indicating whether the current
 iteration is the first or the last iteration, respectively.
@@ -326,7 +326,7 @@ mstch::map extend_struct(const t_struct& strct) const override {
 ```
 
 Where `my_escaping_function` is some function that performs the desired
-escape. From within templates now, as long as a struct is currently in scope,
+escaping. From within templates now, as long as a struct is currently in scope,
 `{{struct:escapedName}}` will refer to the escaped name as defined above, as the
 builtin `dump` functions are aware of the `extend_*` functions.
 

--- a/thrift/doc/internals/mstch.md
+++ b/thrift/doc/internals/mstch.md
@@ -87,7 +87,7 @@ this->write_output("my_output_file.txt", output);
 From within a given template for a generator, other templates may be included
 with the mstch inclusion syntax. If you have an existing template file named
 "Foo.mustache", it can be included by writing `{{> Foo}}`. Templates
-are permitted to recursively include themselves, however care must be taken to
+are permitted to recursively include themselves, however, care must be taken to
 make sure that this terminates.
 
 Note that the final newline, if present in a partial template file, is stripped
@@ -131,7 +131,7 @@ about the context.
 
 Lists represent zero or more elements of some other type, and function similar
 to for-each loops in other languages. The body of the loop will be expanded
-once per element in the list, and on each iteration the context will be
+once per element in the list, and on each iteration, the context will be
 extended using each member of the list. While expanding lists, two boolean keys
 named `first?` and `last?` will be available, indicating whether the current
 iteration is the first or the last iteration, respectively.
@@ -326,7 +326,7 @@ mstch::map extend_struct(const t_struct& strct) const override {
 ```
 
 Where `my_escaping_function` is some function that performs the desired
-escaping. From within templates now, as long as a struct is currently in scope,
+escape. From within templates now, as long as a struct is currently in scope,
 `{{struct:escapedName}}` will refer to the escaped name as defined above, as the
 builtin `dump` functions are aware of the `extend_*` functions.
 


### PR DESCRIPTION
Corrections to minor grammatical mistakes and typos.

**Note:** I was just going through several repositories at meta to look for feasible contribution opportunities and in that process found many small mistakes in the docs. So, thought to start my contribution with this itself. 

Hope it helps perfect the repo! 