### PR TITLE
fix OSS build failure

### DIFF
--- a/thrift/lib/cpp2/server/ThriftServer.cpp
+++ b/thrift/lib/cpp2/server/ThriftServer.cpp
@@ -276,7 +276,7 @@ void ThriftServer::initializeDefaults() {
       methodsBypassMaxRequestsLimit.insert(method);
     }
   }
-  setInternalMethods(std::unordered_set(
+  setInternalMethods(std::unordered_set<std::string>(
       methodsBypassMaxRequestsLimit.begin(),
       methodsBypassMaxRequestsLimit.end()));
   thriftConfig_.methodsBypassMaxRequestsLimit_.setDefault(


### PR DESCRIPTION
Failure could be happening because CTAD is not working properly. 