### PR TITLE
Fix missing `#include <fstream>`

### DIFF
--- a/thrift/compiler/generate/t_mstch_rust_generator.cc
+++ b/thrift/compiler/generate/t_mstch_rust_generator.cc
@@ -16,6 +16,7 @@
 
 #include <cassert>
 #include <cctype>
+#include <fstream>
 #include <set>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
Without this, the build fails with

    error: implicit instantiation of undefined template 'std::basic_ifstream<char>'

Seen while building for Homebrew on macOS 12 at Homebrew/homebrew-core#108112.

The exact error is at https://github.com/Homebrew/homebrew-core/runs/7851989570?check_suite_focus=true#step:6:358.

Closes #512