### PR TITLE
upgrade getdeps GitHub actions to Ubuntu 20 (#1050)

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Fetch ninja

--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -51,22 +51,20 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
     - name: Fetch libtool
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
-    - name: Fetch bison
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests bison
     - name: Fetch libsodium
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
-    - name: Fetch xz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests xz
-    - name: Fetch folly
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
-    - name: Fetch fizz
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch libffi
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libffi
     - name: Fetch ncurses
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests ncurses
     - name: Fetch python
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests python
+    - name: Fetch xz
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests xz
+    - name: Fetch folly
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests folly
+    - name: Fetch fizz
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch wangle
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
     - name: Build ninja
@@ -105,26 +103,24 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
     - name: Build libtool
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
-    - name: Build bison
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests bison
     - name: Build libsodium
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
-    - name: Build xz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
-    - name: Build folly
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
-    - name: Build fizz
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build libffi
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libffi
     - name: Build ncurses
       run: python3 build/fbcode_builder/getdeps.py build --no-tests ncurses
     - name: Build python
       run: python3 build/fbcode_builder/getdeps.py build --no-tests python
+    - name: Build xz
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests xz
+    - name: Build folly
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests folly
+    - name: Build fizz
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build wangle
       run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
     - name: Build fbthrift
-      run: python3 build/fbcode_builder/getdeps.py build --allow-system-packages --src-dir=. fbthrift  --project-install-prefix fbthrift:/usr/local
+      run: python3 build/fbcode_builder/getdeps.py build --src-dir=. fbthrift  --project-install-prefix fbthrift:/usr/local
     - name: Copy artifacts
       run: python3 build/fbcode_builder/getdeps.py fixup-dyn-deps --strip --src-dir=. fbthrift _artifacts/linux  --project-install-prefix fbthrift:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -51,8 +51,6 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests automake
     - name: Fetch libtool
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libtool
-    - name: Fetch bison
-      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests bison
     - name: Fetch libsodium
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests libsodium
     - name: Fetch xz
@@ -99,8 +97,6 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests automake
     - name: Build libtool
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libtool
-    - name: Build bison
-      run: python3 build/fbcode_builder/getdeps.py build --no-tests bison
     - name: Build libsodium
       run: python3 build/fbcode_builder/getdeps.py build --no-tests libsodium
     - name: Build xz

--- a/.github/workflows/getdeps_windows.yml
+++ b/.github/workflows/getdeps_windows.yml
@@ -22,8 +22,6 @@ jobs:
     - name: Disable autocrlf
       run: git config --system core.autocrlf false
     - uses: actions/checkout@v2
-    - name: Fetch bison
-      run: python build/fbcode_builder/getdeps.py fetch --no-tests bison
     - name: Fetch libsodium
       run: python build/fbcode_builder/getdeps.py fetch --no-tests libsodium
     - name: Fetch ninja
@@ -64,8 +62,6 @@ jobs:
       run: python build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch wangle
       run: python build/fbcode_builder/getdeps.py fetch --no-tests wangle
-    - name: Build bison
-      run: python build/fbcode_builder/getdeps.py build --no-tests bison
     - name: Build libsodium
       run: python build/fbcode_builder/getdeps.py build --no-tests libsodium
     - name: Build ninja

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -1115,7 +1115,7 @@ jobs:
             help="Allow CI to fire on all branches - Handy for testing",
         )
         parser.add_argument(
-            "--ubuntu-version", default="18.04", help="Version of Ubuntu to use"
+            "--ubuntu-version", default="20.04", help="Version of Ubuntu to use"
         )
         parser.add_argument(
             "--main-branch",


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/watchman/pull/1050

X-link: https://github.com/facebook/proxygen/pull/426

X-link: https://github.com/facebook/folly/pull/1842

X-link: https://github.com/facebook/fboss/pull/117

Sadly, even though Ubuntu 18.04 is still in LTS, GitHub is deprecating
its runner image.

Migrate the generated GitHub Actions to 20.04.

https://github.com/actions/runner-images/issues/6002

https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

Reviewed By: fanzeyi

Differential Revision: D38877286

