### PR TITLE
Add missing `#include` for macOS Catalina

### DIFF
--- a/thrift/compiler/parse/lexer.cc
+++ b/thrift/compiler/parse/lexer.cc
@@ -17,6 +17,7 @@
 #include <thrift/compiler/parse/lexer.h>
 
 #include <assert.h>
+#include <errno.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Without this, the build fails on macOS Catalina with the error

    error: use of undeclared identifier 'errno'
        errno = 0;
        ^

Notably, this does not happen on macOS Big Sur, Monterey, or on Linux.
Seen while building the latest tag of fbthrift for Homebrew at
Homebrew/homebrew-core#108626.

Build logs available at https://github.com/Homebrew/homebrew-core/runs/7955648533?check_suite_focus=true#step:6:281.
