### PR TITLE
Add -fsized-deallocation compile option (#9218)

### DIFF
--- a/thrift/lib/cpp/CMakeLists.txt
+++ b/thrift/lib/cpp/CMakeLists.txt
@@ -92,6 +92,16 @@ add_library(
   async/TUnframedAsyncChannel.cpp
   server/TServerObserver.cpp
 )
+if (
+  CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
+  CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+)
+  target_compile_options(
+    async
+    PUBLIC
+      $<$<COMPILE_LANGUAGE:CXX>:-fsized-deallocation>
+  )
+endif()
 target_link_libraries(
   async
   PUBLIC


### PR DESCRIPTION
Summary:
Fb-thrift uses C++17's `operator delete`, which requires `-fsized-deallocation` when building c++ source code with clang and libstdc++.

https://github.com/facebook/hhvm/blob/9832791642981d582d0f29c6d89dba2c879cc43d/third-party/thrift/src/thrift/lib/cpp/ContextStack.cpp#L229-L230

X-link: https://github.com/facebook/hhvm/pull/9218

Differential Revision: D39707592

Pulled By: Atry

