### PR TITLE
Add missing #include directive for GCC 13

### DIFF
--- a/thrift/compiler/generate/json.cc
+++ b/thrift/compiler/generate/json.cc
@@ -16,6 +16,7 @@
 
 #include <thrift/compiler/generate/json.h>
 
+#include <cstdint>
 #include <ostream>
 #include <sstream>
 


### PR DESCRIPTION
Found in the just-completed mass rebuild in Fedora Linux in preparation for the upcoming Fedora Linux 38 release.

This is the only thing that needed to be fixed for 2022.07.11.00 to build with GCC 13.0.1.