### PR TITLE
Forward declare enums as well in types_fwd.h

### DIFF
--- a/thrift/compiler/generate/templates/cpp2/module_types_fwd.h.mustache
+++ b/thrift/compiler/generate/templates/cpp2/module_types_fwd.h.mustache
@@ -16,5 +16,22 @@
 
 %><% > Autogen%>
 #pragma once
+<%#program:enums?%>
+
+#include <cstdint>
+<%/program:enums?%>
 
 <% > module_types_h/forward_declare%>
+
+<%#program:enums?%>
+
+// BEGIN forward_declare_enums
+<% > common/namespace_cpp2_begin%>
+
+<%#program:enums%>
+enum <%^enum:cpp_is_unscoped%>class <%/enum:cpp_is_unscoped%><%enum:cpp_name%><%#enum:cpp_enum_type%> : <%enum:cpp_enum_type%><%/enum:cpp_enum_type%>;
+<%/program:enums%>
+<% > common/namespace_cpp2_end%>
+
+// END forward_declare_enums
+<%/program:enums?%>

--- a/thrift/compiler/test/fixtures/adapter/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/adapter/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace facebook { namespace thrift { namespace test {
 class MyAnnotation;
@@ -55,3 +57,10 @@ class Person;
 class Person2;
 }}} // facebook::thrift::test
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace facebook { namespace thrift { namespace test {
+enum class Color;
+enum class ThriftAdaptedEnum;
+}}} // facebook::thrift::test
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/basic-annotations/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/basic-annotations/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace cpp2 {
 class MyStructNestedAnnotation;
@@ -21,3 +23,9 @@ class YourStruct;
 class SecretStruct;
 } // cpp2
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace cpp2 {
+enum class YourEnum;
+} // cpp2
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/basic-enum/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/basic-enum/gen-cpp2/module_types_fwd.h
@@ -6,8 +6,18 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace test { namespace fixtures { namespace enumstrict {
 class MyStruct;
 }}} // test::fixtures::enumstrict
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace test { namespace fixtures { namespace enumstrict {
+enum class EmptyEnum;
+enum class MyEnum;
+enum class MyBigEnum;
+}}} // test::fixtures::enumstrict
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/basic-python-capi/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/basic-python-capi/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace test { namespace fixtures { namespace basic-python-capi {
 class MyStruct;
@@ -34,3 +36,10 @@ class MyDataItemFieldPatchStruct;
 class MyDataItemEnsureStruct;
 }}} // test::fixtures::basic-python-capi
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace test { namespace fixtures { namespace basic-python-capi {
+enum class MyEnum;
+enum class NormalDecentEnum;
+}}} // test::fixtures::basic-python-capi
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/basic-stack-arguments/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/basic-stack-arguments/gen-cpp2/module_types_fwd.h
@@ -6,8 +6,16 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace cpp2 {
 class MyStruct;
 } // cpp2
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace cpp2 {
+enum class MyEnum;
+} // cpp2
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/basic-structured-annotations/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/basic-structured-annotations/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace test { namespace fixtures { namespace basic-structured-annotations {
 class structured_annotation_inline;
@@ -18,3 +20,9 @@ class MyException;
 class MyUnion;
 }}} // test::fixtures::basic-structured-annotations
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace test { namespace fixtures { namespace basic-structured-annotations {
+enum class MyEnum;
+}}} // test::fixtures::basic-structured-annotations
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/basic/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/basic/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace test { namespace fixtures { namespace basic {
 class MyStruct;
@@ -15,3 +17,10 @@ class ReservedKeyword;
 class UnionToBeRenamed;
 }}} // test::fixtures::basic
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace test { namespace fixtures { namespace basic {
+enum class MyEnum;
+enum class HackEnum;
+}}} // test::fixtures::basic
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/complex-struct/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/complex-struct/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace cpp2 {
 class MyStructFloatFieldThrowExp;
@@ -25,3 +27,9 @@ class optXcep;
 class complexException;
 } // cpp2
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace cpp2 {
+enum class MyEnum;
+} // cpp2
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/constants/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/constants/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace cpp2 {
 class Internship;
@@ -18,3 +20,11 @@ class union1;
 class union2;
 } // cpp2
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace cpp2 {
+enum class EmptyEnum;
+enum class City;
+enum class Company;
+} // cpp2
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/deprecated-clear/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/deprecated-clear/gen-cpp2/module_types_fwd.h
@@ -6,8 +6,16 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace apache { namespace thrift { namespace test {
 class StructWithDefaultStruct;
 }}} // apache::thrift::test
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace apache { namespace thrift { namespace test {
+enum class MyEnum;
+}}} // apache::thrift::test
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/doctext/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/doctext/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace cpp2 {
 class A;
@@ -13,3 +15,9 @@ class U;
 class Bang;
 } // cpp2
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace cpp2 {
+enum class B;
+} // cpp2
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/emptiable/gen-cpp2/simple_terse_writes_types_fwd.h
+++ b/thrift/compiler/test/fixtures/emptiable/gen-cpp2/simple_terse_writes_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace apache { namespace thrift { namespace test {
 class MyStruct;
@@ -13,3 +15,9 @@ class EmptiableStruct;
 class NotEmptiableStruct;
 }}} // apache::thrift::test
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace apache { namespace thrift { namespace test {
+enum class MyEnum;
+}}} // apache::thrift::test
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/emptiable/gen-cpp2/simple_types_fwd.h
+++ b/thrift/compiler/test/fixtures/emptiable/gen-cpp2/simple_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace apache { namespace thrift { namespace test {
 class MyStruct;
@@ -14,3 +16,9 @@ class EmptiableTerseStruct;
 class NotEmptiableStruct;
 }}} // apache::thrift::test
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace apache { namespace thrift { namespace test {
+enum class MyEnum;
+}}} // apache::thrift::test
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/encode/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/encode/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace facebook { namespace thrift { namespace test {
 class Foo;
@@ -14,3 +16,9 @@ class Baz;
 class OpEncodeStruct;
 }}} // facebook::thrift::test
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace facebook { namespace thrift { namespace test {
+enum class Enum;
+}}} // facebook::thrift::test
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/enums/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/enums/gen-cpp2/module_types_fwd.h
@@ -6,9 +6,23 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace test { namespace fixtures { namespace enums {
 class SomeStruct;
 class MyStruct;
 }}} // test::fixtures::enums
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace test { namespace fixtures { namespace enums {
+enum class Metasyntactic;
+enum class MyEnum1;
+enum class MyEnum2;
+enum class MyEnum3;
+enum class MyEnum4;
+enum class MyBitmaskEnum1;
+enum class MyBitmaskEnum2;
+}}} // test::fixtures::enums
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/fatal/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/fatal/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace test_cpp2 { namespace cpp_reflection {
 class union1;
@@ -31,3 +33,12 @@ class StructWithFieldAdapter;
 class UnionWithTypedefFieldAdapter;
 }} // test_cpp2::cpp_reflection
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace test_cpp2 { namespace cpp_reflection {
+enum class enum1;
+enum class enum2;
+enum class enum3;
+enum class enum_with_special_names;
+}} // test_cpp2::cpp_reflection
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/frozen-struct/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/frozen-struct/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace some { namespace ns {
 class ModuleA;
@@ -16,3 +18,9 @@ class DirectlyAdapted;
 class CppRef;
 }} // some::ns
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace some { namespace ns {
+enum class EnumB;
+}} // some::ns
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/mcpp2-compare/gen-cpp2/enums_types_fwd.h
+++ b/thrift/compiler/test/fixtures/mcpp2-compare/gen-cpp2/enums_types_fwd.h
@@ -6,8 +6,20 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace facebook { namespace ns { namespace qwerty {
 class SomeStruct;
 }}} // facebook::ns::qwerty
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace facebook { namespace ns { namespace qwerty {
+enum class AnEnumA;
+enum class AnEnumB;
+enum class AnEnumC;
+enum class AnEnumD;
+enum class AnEnumE;
+}}} // facebook::ns::qwerty
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/mcpp2-compare/gen-cpp2/includes_types_fwd.h
+++ b/thrift/compiler/test/fixtures/mcpp2-compare/gen-cpp2/includes_types_fwd.h
@@ -6,9 +6,17 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace a { namespace different { namespace ns {
 class AStruct;
 class AStructB;
 }}} // a::different::ns
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace a { namespace different { namespace ns {
+enum class AnEnum;
+}}} // a::different::ns
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/mcpp2-compare/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/mcpp2-compare/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace some { namespace valid { namespace ns {
 class Empty;
@@ -25,3 +27,12 @@ class FloatUnion;
 class AllRequiredNoExceptMoveCtrStruct;
 }}} // some::valid::ns
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace some { namespace valid { namespace ns {
+enum class MyEnumA;
+enum class AnnotatedEnum : ::std::uint32_t;
+enum class AnnotatedEnum2 : ::std::int16_t;
+enum class MyEnumB;
+}}} // some::valid::ns
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/no-legacy-apis/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/no-legacy-apis/gen-cpp2/module_types_fwd.h
@@ -6,9 +6,17 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace test { namespace fixtures { namespace basic {
 class MyStruct;
 class MyUnion;
 }}} // test::fixtures::basic
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace test { namespace fixtures { namespace basic {
+enum class MyEnum;
+}}} // test::fixtures::basic
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/no_metadata/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/no_metadata/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace cpp2 {
 class MyStruct;
@@ -13,3 +15,9 @@ class MyDataItem;
 class MyUnion;
 } // cpp2
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace cpp2 {
+enum class MyEnum;
+} // cpp2
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/optionals/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/optionals/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace cpp2 {
 class Color;
@@ -13,3 +15,9 @@ class Vehicle;
 class Person;
 } // cpp2
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace cpp2 {
+enum class Animal;
+} // cpp2
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/patch/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/patch/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace test { namespace fixtures { namespace patch {
 class MyData;
@@ -51,3 +53,9 @@ class BarEnsureStruct;
 class LoopPatchStruct;
 }}} // test::fixtures::patch
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace test { namespace fixtures { namespace patch {
+enum class MyEnum;
+}}} // test::fixtures::patch
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/py3/gen-py3cpp/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/py3/gen-py3cpp/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace py3 { namespace simple {
 class SimpleException;
@@ -21,3 +23,11 @@ class BinaryUnion;
 class BinaryUnionStruct;
 }} // py3::simple
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace py3 { namespace simple {
+enum class AnEnum;
+enum class AnEnumRenamed;
+enum class Flags;
+}} // py3::simple
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/refs/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/refs/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace cpp2 {
 class MyUnion;
@@ -28,3 +30,10 @@ class StructWithRefAndAnnotCppNoexceptMoveCtor;
 class StructWithString;
 } // cpp2
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace cpp2 {
+enum class MyEnum;
+enum class TypedEnum : ::std::int16_t;
+} // cpp2
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/service-schema/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/service-schema/gen-cpp2/module_types_fwd.h
@@ -6,8 +6,16 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace cpp2 {
 class CustomException;
 } // cpp2
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace cpp2 {
+enum class Result;
+} // cpp2
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/split/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/split/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace cpp2 {
 class MyStruct;
@@ -13,3 +15,9 @@ class MyDataItem;
 class MyUnion;
 } // cpp2
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace cpp2 {
+enum class MyEnum;
+} // cpp2
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/tablebased/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/tablebased/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace test { namespace fixtures { namespace tablebased {
 class TrivialTypesStruct;
@@ -13,3 +15,9 @@ class ContainerStruct;
 class ExampleUnion;
 }}} // test::fixtures::tablebased
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace test { namespace fixtures { namespace tablebased {
+enum class ExampleEnum;
+}}} // test::fixtures::tablebased
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/templated-deserialize/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/templated-deserialize/gen-cpp2/module_types_fwd.h
@@ -6,9 +6,17 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace cpp2 {
 class SmallStruct;
 class containerStruct;
 } // cpp2
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace cpp2 {
+enum class MyEnumA;
+} // cpp2
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/terse_write/gen-cpp2/deprecated_terse_write_types_fwd.h
+++ b/thrift/compiler/test/fixtures/terse_write/gen-cpp2/deprecated_terse_write_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace facebook { namespace thrift { namespace test { namespace terse_write { namespace deprecated {
 class MyStruct;
@@ -13,3 +15,9 @@ class StructLevelTerseStruct;
 class FieldLevelTerseStruct;
 }}}}} // facebook::thrift::test::terse_write::deprecated
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace facebook { namespace thrift { namespace test { namespace terse_write { namespace deprecated {
+enum class MyEnum;
+}}}}} // facebook::thrift::test::terse_write::deprecated
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/terse_write/gen-cpp2/terse_write_types_fwd.h
+++ b/thrift/compiler/test/fixtures/terse_write/gen-cpp2/terse_write_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace facebook { namespace thrift { namespace test { namespace terse_write {
 class MyStruct;
@@ -19,3 +21,9 @@ class WrappedFields;
 class TerseException;
 }}}} // facebook::thrift::test::terse_write
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace facebook { namespace thrift { namespace test { namespace terse_write {
+enum class MyEnum;
+}}}} // facebook::thrift::test::terse_write
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/types/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/types/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace apache { namespace thrift { namespace fixtures { namespace types {
 class empty_struct;
@@ -49,3 +51,11 @@ class TypedefStruct;
 class StructWithDoubleUnderscores;
 }}}} // apache::thrift::fixtures::types
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace apache { namespace thrift { namespace fixtures { namespace types {
+enum class has_bitwise_ops;
+enum is_unscoped : int;
+enum class MyForwardRefEnum;
+}}}} // apache::thrift::fixtures::types
+// END forward_declare_enums

--- a/thrift/compiler/test/fixtures/visitation/gen-cpp2/module_types_fwd.h
+++ b/thrift/compiler/test/fixtures/visitation/gen-cpp2/module_types_fwd.h
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <cstdint>
+
 // BEGIN forward_declare
 namespace test_cpp2 { namespace cpp_reflection {
 class union1;
@@ -29,3 +31,12 @@ class struct_with_special_names;
 class struct_with_indirections;
 }} // test_cpp2::cpp_reflection
 // END forward_declare
+
+// BEGIN forward_declare_enums
+namespace test_cpp2 { namespace cpp_reflection {
+enum class enum1;
+enum class enum2;
+enum class enum3;
+enum class enum_with_special_names;
+}} // test_cpp2::cpp_reflection
+// END forward_declare_enums


### PR DESCRIPTION
Summary:
Added new forward_declare_enums.mustache template
by copying declare_enums.mustache and turning it into forward declarations only.
Had to handle case of `cpp_is_unscoped` to avoid adding anything for these old fashioned enums.
Played a bunch with empty and new lines to make the final generated code look nice.

Finally, had to handle `#include <cstdint>`.
For now made it simple: if enums are there add this light-weight include.

Reviewed By: Jianmin0105

Differential Revision: D47386766

