### PR TITLE
Do not construct token_kind with non-constant argument

### DIFF
--- a/thrift/compiler/parse/parser.cc
+++ b/thrift/compiler/parse/parser.cc
@@ -653,8 +653,9 @@ class parser {
     }
 
     try_parse_deprecated_annotations(attrs);
-    char delimiter = kind == field_kind::field ? ';' : ',';
     if (token_.kind == ',' || token_.kind == ';') {
+      token_kind delimiter =
+          kind == field_kind::field ? token_kind(';') : token_kind(',');
       if (token_.kind != delimiter) {
         diags_.warning(
             token_.range.begin, "unexpected '{}'", to_string(token_.kind));


### PR DESCRIPTION
Summary:
Do not (implicitely) call token_kind constructor with a non-const expression.

This avoids a build breakage with upcoming llvm/clang versions.

Reviewed By: iahs

Differential Revision: D47642989

