### PR TITLE
Fix mvfst dependency for fbcode_builder/github CI/CD

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -67,6 +67,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch wangle
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
+    - name: Fetch mvfst
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests mvfst
     - name: Build ninja
       run: python3 build/fbcode_builder/getdeps.py build --no-tests ninja
     - name: Build cmake
@@ -119,6 +121,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build wangle
       run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
+    - name: Build mvfst
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests mvfst
     - name: Build fbthrift
       run: python3 build/fbcode_builder/getdeps.py build --src-dir=. fbthrift  --project-install-prefix fbthrift:/usr/local
     - name: Copy artifacts

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -61,6 +61,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch wangle
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests wangle
+    - name: Fetch mvfst
+      run: python3 build/fbcode_builder/getdeps.py fetch --no-tests mvfst
     - name: Build ninja
       run: python3 build/fbcode_builder/getdeps.py build --no-tests ninja
     - name: Build cmake
@@ -107,6 +109,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build wangle
       run: python3 build/fbcode_builder/getdeps.py build --no-tests wangle
+    - name: Build mvfst
+      run: python3 build/fbcode_builder/getdeps.py build --no-tests mvfst
     - name: Build fbthrift
       run: python3 build/fbcode_builder/getdeps.py build --src-dir=. fbthrift  --project-install-prefix fbthrift:/usr/local
     - name: Copy artifacts

--- a/.github/workflows/getdeps_windows.yml
+++ b/.github/workflows/getdeps_windows.yml
@@ -62,6 +62,8 @@ jobs:
       run: python build/fbcode_builder/getdeps.py fetch --no-tests fizz
     - name: Fetch wangle
       run: python build/fbcode_builder/getdeps.py fetch --no-tests wangle
+    - name: Fetch mvfst
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests mvfst
     - name: Build libsodium
       run: python build/fbcode_builder/getdeps.py build --no-tests libsodium
     - name: Build ninja
@@ -102,8 +104,10 @@ jobs:
       run: python build/fbcode_builder/getdeps.py build --no-tests fizz
     - name: Build wangle
       run: python build/fbcode_builder/getdeps.py build --no-tests wangle
+    - name: Build mvfst
+      run: python build/fbcode_builder/getdeps.py build --no-tests mvfst
     - name: Build fbthrift
-      run: python build/fbcode_builder/getdeps.py build --src-dir=. fbthrift 
+      run: python build/fbcode_builder/getdeps.py build --src-dir=. fbthrift
     - name: Copy artifacts
       run: python build/fbcode_builder/getdeps.py fixup-dyn-deps --src-dir=. fbthrift _artifacts/windows  --final-install-prefix /usr/local
     - uses: actions/upload-artifact@v2

--- a/build/deps/github_hashes/facebook/mvfst-rev.txt
+++ b/build/deps/github_hashes/facebook/mvfst-rev.txt
@@ -1,0 +1,1 @@
+Subproject commit bb2a55c392b2a1f93b820d110b72c54d71d6c379

--- a/build/fbcode_builder/manifests/fbthrift
+++ b/build/fbcode_builder/manifests/fbthrift
@@ -23,6 +23,7 @@ fmt
 folly
 googletest
 libsodium
+mvfst
 python-six
 wangle
 zstd


### PR DESCRIPTION
Summary: Add mvfst dependencies for fbcode_builder + github CI/CD workflows
