### PR TITLE
Fix duplicate flags

### DIFF
--- a/thrift/lib/cpp2/CMakeLists.txt
+++ b/thrift/lib/cpp2/CMakeLists.txt
@@ -42,13 +42,15 @@ add_library(
 
   ${metadata-cpp2-SOURCES}
   gen/module_types_cpp.cpp
+  protocol/CompactProtocol.cpp # can't link against thriftprotocol, dep cycle
+  ../cpp/protocol/TProtocolException.cpp
+  ../cpp/util/VarintUtils.cpp
 )
 add_dependencies(thriftmetadata metadata-cpp2-target)
 target_link_libraries(
   thriftmetadata
   PUBLIC
     Folly::folly
-    thriftprotocol
 )
 
 bypass_source_check("${frozen-cpp2-SOURCES}")
@@ -139,13 +141,18 @@ add_library(
 
   ${RpcMetadata-cpp2-SOURCES}
   gen/module_types_cpp.cpp
+  protocol/CompactProtocol.cpp # can't link against thriftprotocol, dep cycle
+  protocol/JSONProtocolCommon.cpp
+  ../cpp/protocol/TBase64Utils.cpp
+  ../cpp/protocol/TJSONProtocol.cpp
+  ../cpp/protocol/TProtocolException.cpp
+  ../cpp/util/VarintUtils.cpp
 )
 add_dependencies(rpcmetadata RpcMetadata-cpp2-target)
 target_link_libraries(
   rpcmetadata
   PUBLIC
     Folly::folly
-    thriftprotocol
 )
 
 bypass_source_check("${reflection-cpp2-SOURCES}")

--- a/thrift/lib/cpp2/CMakeLists.txt
+++ b/thrift/lib/cpp2/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(
   thriftmetadata
   PUBLIC
     Folly::folly
+    thriftprotocolflags
 )
 
 bypass_source_check("${frozen-cpp2-SOURCES}")
@@ -153,6 +154,21 @@ target_link_libraries(
   rpcmetadata
   PUBLIC
     Folly::folly
+    thriftprotocolflags
+)
+
+# Some of the thriftprotocol sources are duplicated in other libraries.
+# This fails when those sources contain gflags. This library contains
+# the definitions of all the gflags used by thriftprotocol sources.
+add_library(
+  thriftprotocolflags
+
+  protocol/ProtocolGFlags.cpp
+)
+target_link_libraries(
+  thriftprotocolflags
+  PUBLIC
+    Folly::folly
 )
 
 bypass_source_check("${reflection-cpp2-SOURCES}")
@@ -189,6 +205,7 @@ target_link_libraries(
     wangle::wangle
     ${GLOG_LIBRARIES}
     thrift-core
+    thriftprotocolflags
 )
 
 bypass_source_check("${RocketUpgrade-cpp2-SOURCES}")
@@ -329,6 +346,7 @@ target_link_libraries(
     thriftmetadata
     thriftfrozen2
     thriftprotocol
+    thriftprotocolflags
     thrifttyperep
     thrifttype
     thriftanyrep
@@ -370,7 +388,8 @@ install(
 
 if (BUILD_SHARED_LIBS)
   set_target_properties(rpcmetadata thriftannotation thriftmetadata
-    thriftfrozen2 thriftprotocol thriftcpp2 thrifttyperep thrifttype
+    thriftfrozen2 thriftprotocol thriftprotocolflags thriftcpp2 thrifttyperep
+    thrifttype
     PROPERTIES VERSION ${PACKAGE_VERSION}
     )
 endif()
@@ -384,6 +403,7 @@ install(
     thrifttype
     thriftanyrep
     thriftprotocol
+    thriftprotocolflags
     thriftcpp2
   EXPORT fbthrift-exports
   DESTINATION ${LIB_INSTALL_DIR}

--- a/thrift/lib/cpp2/protocol/BinaryProtocol.cpp
+++ b/thrift/lib/cpp2/protocol/BinaryProtocol.cpp
@@ -17,16 +17,6 @@
 #include <thrift/lib/cpp2/protocol/BinaryProtocol.h>
 
 #include <folly/Conv.h>
-#include <folly/portability/GFlags.h>
-
-FOLLY_GFLAGS_DEFINE_int32(
-    thrift_cpp2_protocol_reader_string_limit,
-    0,
-    "Limit on string size when deserializing thrift, 0 is no limit");
-FOLLY_GFLAGS_DEFINE_int32(
-    thrift_cpp2_protocol_reader_container_limit,
-    0,
-    "Limit on container size when deserializing thrift, 0 is no limit");
 
 namespace apache {
 namespace thrift {

--- a/thrift/lib/cpp2/protocol/BinaryProtocol.h
+++ b/thrift/lib/cpp2/protocol/BinaryProtocol.h
@@ -21,12 +21,9 @@
 #include <folly/io/IOBuf.h>
 #include <folly/io/IOBufQueue.h>
 #include <folly/lang/Bits.h>
-#include <folly/portability/GFlags.h>
 #include <thrift/lib/cpp/protocol/TProtocol.h>
 #include <thrift/lib/cpp2/protocol/Protocol.h>
-
-FOLLY_GFLAGS_DECLARE_int32(thrift_cpp2_protocol_reader_string_limit);
-FOLLY_GFLAGS_DECLARE_int32(thrift_cpp2_protocol_reader_container_limit);
+#include <thrift/lib/cpp2/protocol/ProtocolGFlags.h>
 
 namespace apache {
 namespace thrift {

--- a/thrift/lib/cpp2/protocol/CompactProtocol.h
+++ b/thrift/lib/cpp2/protocol/CompactProtocol.h
@@ -27,9 +27,7 @@
 #include <folly/small_vector.h>
 #include <thrift/lib/cpp/protocol/TProtocol.h>
 #include <thrift/lib/cpp2/protocol/Protocol.h>
-
-FOLLY_GFLAGS_DECLARE_int32(thrift_cpp2_protocol_reader_string_limit);
-FOLLY_GFLAGS_DECLARE_int32(thrift_cpp2_protocol_reader_container_limit);
+#include <thrift/lib/cpp2/protocol/ProtocolGFlags.h>
 
 namespace apache {
 namespace thrift {

--- a/thrift/lib/cpp2/protocol/DebugProtocol.cpp
+++ b/thrift/lib/cpp2/protocol/DebugProtocol.cpp
@@ -19,15 +19,6 @@
 #include <folly/Conv.h>
 #include <folly/String.h>
 
-FOLLY_GFLAGS_DEFINE_bool(
-    thrift_cpp2_debug_skip_list_indices,
-    false,
-    "Wether to skip indices when debug-printing lists (unless overridden)");
-FOLLY_GFLAGS_DEFINE_int64(
-    thrift_cpp2_debug_string_limit,
-    256,
-    "Limit on string size when debug-printing thrift, 0 is no limit");
-
 namespace apache {
 namespace thrift {
 

--- a/thrift/lib/cpp2/protocol/DebugProtocol.h
+++ b/thrift/lib/cpp2/protocol/DebugProtocol.h
@@ -20,14 +20,11 @@
 #include <fmt/core.h>
 #include <folly/io/Cursor.h>
 #include <folly/io/IOBuf.h>
-#include <folly/portability/GFlags.h>
 #include <thrift/lib/cpp2/Thrift.h>
 #include <thrift/lib/cpp2/protocol/Cpp2Ops.h>
 #include <thrift/lib/cpp2/protocol/Protocol.h>
+#include <thrift/lib/cpp2/protocol/ProtocolGFlags.h>
 #include <thrift/lib/cpp2/type/NativeType.h>
-
-FOLLY_GFLAGS_DECLARE_bool(thrift_cpp2_debug_skip_list_indices);
-FOLLY_GFLAGS_DECLARE_int64(thrift_cpp2_debug_string_limit);
 
 namespace apache {
 namespace thrift {

--- a/thrift/lib/cpp2/protocol/JSONProtocolCommon.cpp
+++ b/thrift/lib/cpp2/protocol/JSONProtocolCommon.cpp
@@ -19,13 +19,6 @@
 #include <type_traits>
 
 #include <fmt/core.h>
-#include <folly/portability/GFlags.h>
-
-FOLLY_GFLAGS_DEFINE_bool(
-    thrift_cpp2_simple_json_base64_allow_padding,
-    true,
-    "Allow '=' padding when decoding base64 encoded binary fields in "
-    "SimpleJsonProtocol");
 
 namespace {
 

--- a/thrift/lib/cpp2/protocol/JSONProtocolCommon.h
+++ b/thrift/lib/cpp2/protocol/JSONProtocolCommon.h
@@ -28,11 +28,9 @@
 #include <folly/io/IOBuf.h>
 #include <folly/io/IOBufQueue.h>
 #include <folly/json.h>
-#include <folly/portability/GFlags.h>
 #include <thrift/lib/cpp/protocol/TBase64Utils.h>
 #include <thrift/lib/cpp2/protocol/Protocol.h>
-
-FOLLY_GFLAGS_DECLARE_bool(thrift_cpp2_simple_json_base64_allow_padding);
+#include <thrift/lib/cpp2/protocol/ProtocolGFlags.h>
 
 namespace apache {
 namespace thrift {

--- a/thrift/lib/cpp2/protocol/Protocol.cpp
+++ b/thrift/lib/cpp2/protocol/Protocol.cpp
@@ -16,12 +16,7 @@
 
 #include <thrift/lib/cpp2/protocol/Protocol.h>
 
-#include <folly/portability/GFlags.h>
-
-FOLLY_GFLAGS_DEFINE_int32(
-    thrift_protocol_max_depth,
-    15000,
-    "How many nested struct/list/set/map are allowed");
+#include <thrift/lib/cpp2/protocol/ProtocolGFlags.h>
 
 namespace apache {
 namespace thrift {

--- a/thrift/lib/cpp2/protocol/ProtocolGFlags.cpp
+++ b/thrift/lib/cpp2/protocol/ProtocolGFlags.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/portability/GFlags.h>
+#include <thrift/lib/cpp2/protocol/ProtocolGFlags.h>
+
+FOLLY_GFLAGS_DEFINE_int32(
+    thrift_protocol_max_depth,
+    15000,
+    "How many nested struct/list/set/map are allowed");
+
+FOLLY_GFLAGS_DEFINE_int32(
+    thrift_cpp2_protocol_reader_string_limit,
+    0,
+    "Limit on string size when deserializing thrift, 0 is no limit");
+FOLLY_GFLAGS_DEFINE_int32(
+    thrift_cpp2_protocol_reader_container_limit,
+    0,
+    "Limit on container size when deserializing thrift, 0 is no limit");
+
+FOLLY_GFLAGS_DEFINE_bool(
+    thrift_cpp2_simple_json_base64_allow_padding,
+    true,
+    "Allow '=' padding when decoding base64 encoded binary fields in "
+    "SimpleJsonProtocol");
+
+FOLLY_GFLAGS_DEFINE_bool(
+    thrift_cpp2_debug_skip_list_indices,
+    false,
+    "Wether to skip indices when debug-printing lists (unless overridden)");
+FOLLY_GFLAGS_DEFINE_int64(
+    thrift_cpp2_debug_string_limit,
+    256,
+    "Limit on string size when debug-printing thrift, 0 is no limit");

--- a/thrift/lib/cpp2/protocol/ProtocolGFlags.h
+++ b/thrift/lib/cpp2/protocol/ProtocolGFlags.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/portability/GFlags.h>
+
+/**
+ * All GFlags used by protocols are declared here and defined in
+ * ProtocolGFlags.cpp.
+ *
+ * This is necessary because the CMake build system includes some of the
+ * protocol sources in multiple libraries. When building with shared libraries,
+ * this causes each library that contains the sources to register the flags,
+ * which causes gflags to crash.
+ *
+ * To avoid the problem, we centralize all the flags and make that one CMake
+ * library. Then each library which includes some protocol sources adds a
+ * dependency on this library.
+ */
+
+FOLLY_GFLAGS_DECLARE_int32(thrift_protocol_max_depth);
+
+FOLLY_GFLAGS_DECLARE_int32(thrift_cpp2_protocol_reader_string_limit);
+FOLLY_GFLAGS_DECLARE_int32(thrift_cpp2_protocol_reader_container_limit);
+
+FOLLY_GFLAGS_DECLARE_bool(thrift_cpp2_simple_json_base64_allow_padding);
+
+FOLLY_GFLAGS_DECLARE_bool(thrift_cpp2_debug_skip_list_indices);
+FOLLY_GFLAGS_DECLARE_int64(thrift_cpp2_debug_string_limit);


### PR DESCRIPTION
Summary:
D50505357 attempted to fix the issue, but introduced dependency cycles that weren't caught by CI.

This diff fixes the issue by moving all the GFlag definitions to `ProtocolGFlags.cpp` and exposing this as a separate library `thriftprotocolflags` in CMake. Each library which includes a copy of the protocol sources depends on this library.

Differential Revision: D50521352


