### PR TITLE
feat: support pyodide on bypass fcntl call

### DIFF
--- a/thrift/lib/py/transport/TSocket.py
+++ b/thrift/lib/py/transport/TSocket.py
@@ -208,6 +208,11 @@ class TSocketBase(TTransportBase):
         if fcntl is None:
             return
 
+        # pyodide doesn't support fcntl, so we need to skip in this case, too.
+        # ref: https://github.com/pyodide/pyodide/discussions/4150
+        if sys.platform == 'emscripten':
+            return
+
         flags = fcntl.fcntl(handle, fcntl.F_GETFD, 0)
         if flags < 0:
             raise IOError("Error in retrieving file options")

--- a/thrift/lib/py/transport/TSocket.py
+++ b/thrift/lib/py/transport/TSocket.py
@@ -208,9 +208,8 @@ class TSocketBase(TTransportBase):
         if fcntl is None:
             return
 
-        # pyodide doesn't support fcntl, so we need to skip in this case, too.
-        # ref: https://github.com/pyodide/pyodide/discussions/4150
-        if sys.platform == 'emscripten':
+        # Skip if fcntl.fcntl is not available (this can happen in env like Pyodide)
+        if not hasattr(fcntl, "fcntl"):
             return
 
         flags = fcntl.fcntl(handle, fcntl.F_GETFD, 0)


### PR DESCRIPTION
For fbthrift python on jupyterlite/pyodide, [fcntl is not yet supported]( https://github.com/pyodide/pyodide/discussions/4150) , it's worth bypassing it in such cases similar to the Windows case.