### PR TITLE
Fix a race condition with ninja 1.12.0

### DIFF
--- a/thrift/lib/cpp2/CMakeLists.txt
+++ b/thrift/lib/cpp2/CMakeLists.txt
@@ -109,8 +109,8 @@ add_library(
   type/TypeRegistry.cpp
   type/UniversalName.cpp
 )
-add_dependencies(thrifttype type-cpp2-target thriftannotation thrifttyperep
-  thriftprotocol)
+add_dependencies(thrifttype any_rep-cpp2-target type-cpp2-target
+  thriftannotation thrifttyperep thriftprotocol)
 target_link_libraries(
   thrifttype
   PUBLIC


### PR DESCRIPTION
Fix a race condition that exists when building with ninja 1.12.0 where any_rep_types.h is not generated before attempting to compile Any.cpp.

`[ 57% 214/369] /usr/local/libexec/ccache/c++ -DFMT_SHARED -DGFLAGS_IS_A_DLL=0 -DTHRIFT_HAVE_LIBSNAPPY=0 -Dthrifttype_EXPORTS -I/wrkdirs/usr/ports/devel/fbthrift/work/fbthrift-2024.05.02.00/. -I/wrkdirs/usr/ports/devel/fbthrift/work/.build -isystem /usr/local/include -O2 -pipe -fstack-protector-strong -fno-strict-aliasing  -fPIC -DGLOG_USE_GLOG_EXPORT -O2 -pipe -fstack-protector-strong -fno-strict-aliasing  -fPIC -DGLOG_USE_GLOG_EXPORT  -DNDEBUG -std=c++17 -fPIC -pthread -fsized-deallocation -MD -MT thrift/lib/cpp2/CMakeFiles/thrifttype.dir/type/Any.cpp.o -MF thrift/lib/cpp2/CMakeFiles/thrifttype.dir/type/Any.cpp.o.d -o thrift/lib/cpp2/CMakeFiles/thrifttype.dir/type/Any.cpp.o -c /wrkdirs/usr/ports/devel/fbthrift/work/fbthrift-2024.05.02.00/thrift/lib/cpp2/type/Any.cpp`
`FAILED: thrift/lib/cpp2/CMakeFiles/thrifttype.dir/type/Any.cpp.o`
`/usr/local/libexec/ccache/c++ -DFMT_SHARED -DGFLAGS_IS_A_DLL=0 -DTHRIFT_HAVE_LIBSNAPPY=0 -Dthrifttype_EXPORTS -I/wrkdirs/usr/ports/devel/fbthrift/work/fbthrift-2024.05.02.00/. -I/wrkdirs/usr/ports/devel/fbthrift/work/.build -isystem /usr/local/include -O2 -pipe -fstack-protector-strong -fno-strict-aliasing  -fPIC -DGLOG_USE_GLOG_EXPORT -O2 -pipe -fstack-protector-strong -fno-strict-aliasing  -fPIC -DGLOG_USE_GLOG_EXPORT  -DNDEBUG -std=c++17 -fPIC -pthread -fsized-deallocation -MD -MT thrift/lib/cpp2/CMakeFiles/thrifttype.dir/type/Any.cpp.o -MF thrift/lib/cpp2/CMakeFiles/thrifttype.dir/type/Any.cpp.o.d -o thrift/lib/cpp2/CMakeFiles/thrifttype.dir/type/Any.cpp.o -c /wrkdirs/usr/ports/devel/fbthrift/work/fbthrift-2024.05.02.00/thrift/lib/cpp2/type/Any.cpp
In file included from /wrkdirs/usr/ports/devel/fbthrift/work/fbthrift-2024.05.02.00/thrift/lib/cpp2/type/Any.cpp:17:
/wrkdirs/usr/ports/devel/fbthrift/work/fbthrift-2024.05.02.00/./thrift/lib/cpp2/type/Any.h:23:10: fatal error: 'thrift/lib/thrift/gen-cpp2/any_rep_types.h' file not found`
`#include <thrift/lib/thrift/gen-cpp2/any_rep_types.h>`
`         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`
`1 error generated.`
`ninja: build stopped: subcommand failed.`
`*** Error code 1`