### PR TITLE
refactor: use EVP API with OpenSSL 3 over deprecated SHA256_* API

### DIFF
--- a/thrift/compiler/lib/cpp2/util.cc
+++ b/thrift/compiler/lib/cpp2/util.cc
@@ -23,7 +23,11 @@
 #include <queue>
 #include <stdexcept>
 
+#include <openssl/opensslv.h>
 #include <openssl/sha.h>
+#if OPENSSL_VERSION_NUMBER >= x030000000  // v3.0.0
+#include <openssl/evp.h>
+#endif
 
 #include <fmt/core.h>
 
@@ -604,10 +608,14 @@ std::string get_gen_type_class_with_indirection(t_type const& type) {
 
 std::string sha256_hex(std::string const& in) {
   std::uint8_t mid[SHA256_DIGEST_LENGTH];
+#if OPENSSL_VERSION_NUMBER >= x030000000  // v3.0.0
+  EVP_Digest(in.data(), in.size(), mid, nullptr, EVP_sha256(), nullptr);
+#else
   SHA256_CTX hasher;
   SHA256_Init(&hasher);
   SHA256_Update(&hasher, in.data(), in.size());
   SHA256_Final(mid, &hasher);
+#endif
 
   constexpr auto alpha = "0123456789abcdef";
 


### PR DESCRIPTION
This prevents deprecation warnings when building against OpenSSL 3.