### PR TITLE
fix: missing cmake deps for target `compiler_generators`

### DIFF
--- a/thrift/compiler/CMakeLists.txt
+++ b/thrift/compiler/CMakeLists.txt
@@ -130,6 +130,7 @@ add_library(
   lib/go/util.cc
   lib/java/util.cc
   lib/rust/util.cc
+  lib/python/util.cc
 )
 target_link_libraries(
   compiler


### PR DESCRIPTION
https://github.com/facebook/fbthrift/commit/7a59c59124dd89f6247fd2e47f324fc08a029a45