### PR TITLE
CMakeLists: fix set_target_properties incorrect number of arguments

### DIFF
--- a/thrift/compiler/generate/CMakeLists.txt
+++ b/thrift/compiler/generate/CMakeLists.txt
@@ -44,7 +44,7 @@ list(REMOVE_ITEM GENERATOR_FILES t_ast_generator.cc)
 add_library(compiler_generators STATIC ${GENERATOR_FILES}
             ${CMAKE_CURRENT_BINARY_DIR}/templates.cc)
 set_target_properties(compiler_generators PROPERTIES
-                      POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
+                      POSITION_INDEPENDENT_CODE "${BUILD_SHARED_LIBS}")
 target_link_libraries(
   compiler_generators
   compiler_ast


### PR DESCRIPTION
Fix a configure failure due to a wrong number of arguments to `set_target_properties`