### PR TITLE
fix: fmt v11 moves fmt::join to fmt/ranges.h

### DIFF
--- a/thrift/compiler/gen/cpp/namespace_resolver.cc
+++ b/thrift/compiler/gen/cpp/namespace_resolver.cc
@@ -16,7 +16,7 @@
 
 #include <thrift/compiler/gen/cpp/namespace_resolver.h>
 
-#include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace apache {
 namespace thrift {

--- a/thrift/compiler/generate/t_hack_generator.cc
+++ b/thrift/compiler/generate/t_hack_generator.cc
@@ -42,6 +42,8 @@
 #include <thrift/compiler/generate/t_concat_generator.h>
 #include <thrift/compiler/lib/uri.h>
 
+#include <fmt/ranges.h>
+
 namespace apache::thrift::compiler {
 namespace {
 

--- a/thrift/compiler/lib/cpp2/util.h
+++ b/thrift/compiler/lib/cpp2/util.h
@@ -37,7 +37,7 @@
 #include <thrift/compiler/gen/cpp/reference_type.h>
 #include <thrift/compiler/lib/uri.h>
 
-#include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace apache {
 namespace thrift {


### PR DESCRIPTION
When building against fmt v11, `fmt::join` is no longer found when only including `fmt/format.h`.