### PR TITLE
Conditionally enable coroutines if supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,12 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Explicitly enable coroutine support, since GCC does not enable it
+# by default when targeting C++17.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fcoroutines>)
+endif()
+
 # Enable modular builds.
 option(THRIFT_COMPILER_ONLY "Build the Thrift compiler only" OFF)
 option(THRIFT_LIB_ONLY "Build the Thrift libraries only" OFF)


### PR DESCRIPTION
fbthrift is still on C++17, so GCC will only enable support for coroutines if -fcoroutines is passed, which is not the case currently. This, however, creates confusion when fbthrift is used as a dependency of a project that's already using C++20 or newer. In such a scenario, GCC >= 11 will enable coroutine support by default, so generated client code will be compiled using coroutines and then fail because fbthrift was built without coroutine support.

So, conditionally enable coroutines if the compiler supports them, like folly and co. do already.