### PR TITLE
Defer cpp2 union move compilations

### DIFF
--- a/thrift/compiler/generate/templates/cpp2/module_types_h/union_moves.mustache
+++ b/thrift/compiler/generate/templates/cpp2/module_types_h/union_moves.mustache
@@ -15,7 +15,8 @@
   limitations under the License.
 
 }}{{#struct:legacy_api?}}{{#struct:fields}}
-  {{!deprecated}}{{field:cpp_storage_type}} move_{{field:cpp_name}}() {
+  template <typename..., typename T = {{field:cpp_storage_type}}>
+  {{!deprecated}}T move_{{field:cpp_name}}() {
     assert(getType() == Type::{{field:cpp_name}});
     return std::move(value_.{{field:cpp_name}});
   }


### PR DESCRIPTION
The move accessors in generated cpp2 thrift code suffer from an eager compilation issue similar to the one reported for union setters in #508, when compiling with clang / libstdc++
(https://godbolt.org/z/KGr9cM5n5).

As a fix, make these accessors templated, like the field ref accessors, to defer compilation.