### PR TITLE
getdeps: fix xxhash build on windows

### DIFF
--- a/build/fbcode_builder/manifests/xxhash
+++ b/build/fbcode_builder/manifests/xxhash
@@ -25,3 +25,6 @@ all
 [make.install_args]
 install
 
+[build.os=windows]
+builder = cmake
+subdir = xxHash-0.8.2/cmake_unofficial


### PR DESCRIPTION
getdeps: fix xxhash build on windows

Summary:
fbthrift needs xxhash but xxhash manifest had no builder defined on windows

Add xxhash windows build support using cmake

Test Plan:

build xxhash locally on windows with:
`python ./build/fbcode_builder/getdeps.py build xxhash`

Before [broken, no builder](https://github.com/ahornby/fbthrift/actions/runs/11401030867/job/31723096967#step:31:23)
```
Mapping scratch dir C:\Users\RUNNER~1\AppData\Local\Temp\fbcode_builder_getdeps-DZZaZfbthriftZfbthriftZbuildZfbcode_builder -> Z:\
Building on {distro=None, distro_vers=10, fb=off, fbsource=off, os=windows, shared_libs=off, test=off}
Assessing xxhash...
Traceback (most recent call last):
  File "build/fbcode_builder/getdeps.py", line 1452, in <module>
    sys.exit(main())
  File "build/fbcode_builder/getdeps.py", line 1435, in main
    return args.func(args)
  File "build/fbcode_builder/getdeps.py", line 108, in run
    self.run_project_cmd(args, loader, manifest)
  File "build/fbcode_builder/getdeps.py", line 653, in run_project_cmd
    dep_manifests,
  File "D:\a\fbthrift\fbthrift\build\fbcode_builder\getdeps\manifest.py", line 685, in create_prepare_builders
    builder = self.get_builder_name(ctx)
  File "D:\a\fbthrift\fbthrift\build\fbcode_builder\getdeps\manifest.py", line 481, in get_builder_name
    raise Exception("project %s has no builder for %r" % (self.name, ctx))
Exception: project xxhash has no builder for <getdeps.manifest.ManifestContext object at 0x0000021606FDE388>
```

After, works:
```
$ python ./build/fbcode_builder/getdeps.py build  xxhash
Mapping scratch dir C:\Users\alex\AppData\Local\Temp\fbcode_builder_getdeps-CZZUsersZalexZlocalZfbthriftZbuildZfbcode_builder -> Z:\
Building on {distro=None, distro_vers=10, fb=off, fbsource=off, os=windows, shared_libs=off, test=on}
Assessing ninja...
Assessing cmake...
Assessing xxhash...

alex@fridge MINGW64 ~/local/fbthrift
$ echo $?
0
```
