### PR TITLE
install .thrift files fb303 build complains are missing

### DIFF
--- a/thrift/lib/CMakeLists.txt
+++ b/thrift/lib/CMakeLists.txt
@@ -38,3 +38,9 @@ foreach(dir ${LIB_DIRS})
           PATTERN "*.tcc"
           PATTERN CMakeFiles EXCLUDE)
 endforeach()
+
+install(
+  DIRECTORY thrift "${CMAKE_CURRENT_SOURCE_DIR}/thrift"
+  DESTINATION include/thrift/lib
+  FILES_MATCHING PATTERN *.thrift
+)


### PR DESCRIPTION

Summary:

Install .thrift files fb303 build complains about.
Fixes  warnings in fb303 build like `[WARNING:] Could not load Thrift standard libraries: Could not find include file thrift/lib/thrift/schema.thrift`

Test Plan:

build fbthrift and look at output
```
$ ls /home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/installed/fbthrift/include/thrift/lib/thrift/
any_patch_detail.thrift  any.thrift  dynamic.thrift     gen-cpp2         patch_op.thrift         protocol.thrift       RpcMetadata_extra.h  SerializableDynamic.h  type_rep.thrift
any_patch.thrift         ast.thrift  field_mask.thrift  id.thrift        patch.thrift            reflection.thrift     RpcMetadata.thrift   serverdbginfo.thrift   type.thrift
any_rep.thrift           detail      frozen.thrift      metadata.thrift  protocol_detail.thrift  RocketUpgrade.thrift  schema.thrift        standard.thrift        TypeToMaskAdapter.h
```

build fb303

Before, warnings"Could not load Thrift standard libraries: "
```
[2/35] Generating gen-cpp2/fb303_core_constants.h, gen-cpp2/fb303_core_types.h, gen-cpp2/fb303_c...ent.cpp, gen-cpp2/BaseService_processmap_binary.cpp, gen-cpp2/BaseService_processmap_compact.cpp
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:52] The annotation priority is deprecated. Please use @thrift.Priority instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:71] The annotation priority is deprecated. Please use @thrift.Priority instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:76] The annotation thread is deprecated. Please use @cpp.ProcessInEbThreadUnsafe instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:82] The annotation thread is deprecated. Please use @cpp.ProcessInEbThreadUnsafe instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:89] The annotation thread is deprecated. Please use @cpp.ProcessInEbThreadUnsafe instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:94] The annotation priority is deprecated. Please use @thrift.Priority instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:99] The annotation priority is deprecated. Please use @thrift.Priority instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:106] The annotation priority is deprecated. Please use @thrift.Priority instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:119] The annotation priority is deprecated. Please use @thrift.Priority instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:139] The annotation priority is deprecated. Please use @thrift.Priority instead.
[WARNING:] Could not load Thrift standard libraries: Could not find include file thrift/lib/thrift/schema.thrift
[3/35] Generating fb303_thrift_py.lib_install/fb303_thrift_py.manifest

```

After, missing include file warnings gone
```
[2/35] Generating gen-cpp2/fb303_core_constants.h, gen-cpp2/fb303_core_types.h, gen-cpp2/fb303_c...ent.cpp, gen-cpp2/BaseService_processmap_binary.cpp, gen-cpp2/BaseService_processmap_compact.cpp
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:52] The annotation priority is deprecated. Please use @thrift.Priority instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:71] The annotation priority is deprecated. Please use @thrift.Priority instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:76] The annotation thread is deprecated. Please use @cpp.ProcessInEbThreadUnsafe instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:82] The annotation thread is deprecated. Please use @cpp.ProcessInEbThreadUnsafe instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:89] The annotation thread is deprecated. Please use @cpp.ProcessInEbThreadUnsafe instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:94] The annotation priority is deprecated. Please use @thrift.Priority instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:99] The annotation priority is deprecated. Please use @thrift.Priority instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:106] The annotation priority is deprecated. Please use @thrift.Priority instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:119] The annotation priority is deprecated. Please use @thrift.Priority instead.
[WARNING:/home/alex/local/tmp/fridge/fbcode_builder_getdeps-ZhomeZalexZlocalZsapling-slZbuildZfbcode_builder/repos/github.com-facebook-fb303.git/fb303/thrift/fb303_core.thrift:139] The annotation priority is deprecated. Please use @thrift.Priority instead.
[3/35] Generating fb303_thrift_py.lib_install/fb303_thrift_py.manifest
```
