### PR TITLE
Fix OSS build

### DIFF
--- a/thrift/compiler/CMakeLists.txt
+++ b/thrift/compiler/CMakeLists.txt
@@ -168,6 +168,7 @@ add_library(
 
   whisker/detail/string.cc
   whisker/ast.cc
+  whisker/dsl.cc
   whisker/eval_context.cc
   whisker/lexer.cc
   whisker/mstch_compat.cc


### PR DESCRIPTION
dsl.cc was added to whisker in aa4d96b6d058dba03eb1a3c68b8fa2c4c23e3e94 but is missing from the corresponding listfile.