### PR TITLE
Fix OSS build

### DIFF
--- a/thrift/compiler/CMakeLists.txt
+++ b/thrift/compiler/CMakeLists.txt
@@ -153,16 +153,6 @@ target_link_libraries(
 )
 
 add_library(
-  mustache
-  detail/mustache/mstch.cpp
-)
-target_link_libraries(
-  mustache
-  Boost::boost
-  fmt::fmt
-)
-
-add_library(
   whisker
   STATIC
 
@@ -227,7 +217,6 @@ if (BUILD_SHARED_LIBS)
     compiler_base
     compiler_lib
     compiler
-    mustache
     whisker
     compiler_generators
     PROPERTIES VERSION ${PACKAGE_VERSION}
@@ -240,7 +229,6 @@ install(
     compiler_base
     compiler_lib
     compiler
-    mustache
     whisker
   EXPORT fbthrift-exports
   RUNTIME DESTINATION ${BIN_INSTALL_DIR}

--- a/thrift/compiler/generate/CMakeLists.txt
+++ b/thrift/compiler/generate/CMakeLists.txt
@@ -51,7 +51,6 @@ target_link_libraries(
   compiler_base
   compiler_lib
   compiler
-  mustache
   whisker
   ${OPENSSL_LIBRARIES}
 )


### PR DESCRIPTION
mstch was moved to whisker/mstch_compat.h for compatibility in 57f8de80f181c20d7c531685af1f4fa9cff43b20.

We need to remove mustache from the corresponding CMakeLists.txt files to fix it.