### PR TITLE
Fix {fmt} breaking OSS build

### DIFF
--- a/thrift/compiler/generate/t_whisker_generator.cc
+++ b/thrift/compiler/generate/t_whisker_generator.cc
@@ -27,7 +27,7 @@
 #include <cstddef>
 #include <fstream>
 
-#include <fmt/core.h>
+#include <fmt/ranges.h>
 
 #include <boost/algorithm/string/split.hpp>
 


### PR DESCRIPTION
As t_whisker_generator was introduced in bbbd038c9c5f2b1311e4d4d54c60fd022dc3ac19, it broke the OSS build with `error: ‘join’ is not a member of ‘fmt’`.

The newer versions of {fmt} have `fmt::join` in `fmt/ranges.h`.

Fixes:

```
thrift/compiler/generate/t_whisker_generator.cc:117:40: error: ‘join’ is not a member of ‘fmt’
  117 |         "{}/{}", template_prefix, fmt::join(start, partial_path.end(), "/"));
      |                                        ^~~~
```

https://github.com/facebook/fbthrift/actions/runs/12822463794/job/35755425223