### PR TITLE
Fix OSS build

### DIFF
--- a/thrift/compiler/CMakeLists.txt
+++ b/thrift/compiler/CMakeLists.txt
@@ -120,6 +120,7 @@ add_library(
   parse/token.cc
   parse/token.h
   sema/check_initializer.cc
+  sema/check_map_keys.cc
   sema/explicit_include_validator.cc
   sema/scope_validator.cc
   sema/sema.cc


### PR DESCRIPTION
added `check_map_keys.cc` to the `compiler_lib` target in `thrift/compiler/CMakeLists.txt`.

This file was introduced in 14b6eae5028bb0c6f2e376283ecbcaa05be4a38b and broke the OSS build.