### PR TITLE
build: update cmake_minimum_required to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 # Package information.
 if (NOT DEFINED PACKAGE_VERSION)


### PR DESCRIPTION
Compatibility with versions older than 3.5 has been deprecated since cmake 3.27 and has now been removed with cmake 4.0. Compatibility with versions before 3.10 has been deprecated since cmake 3.31.

This changes the requirement to 3.10 to allow this project to still be built with cmake 4.0 without any deprecation warning.