### PR TITLE
fix: explicitly mark unreachable code to prevent GCC warnings

### DIFF
--- a/thrift/compiler/ast/t_type.cc
+++ b/thrift/compiler/ast/t_type.cc
@@ -159,6 +159,7 @@ std::optional<t_type::value_type> t_type::as_value_type() const {
     case type::t_void:
       return std::nullopt;
   }
+  abort();
 }
 
 } // namespace apache::thrift::compiler

--- a/thrift/compiler/ast/type_visitor.h
+++ b/thrift/compiler/ast/type_visitor.h
@@ -71,6 +71,7 @@ decltype(auto) visit_type(const t_type& ty, Visitors&&... visitors) {
     case t_type::type::t_service:
       return std::invoke(f, dynamic_cast<const t_service&>(ty));
   }
+  abort();
 }
 
 } // namespace apache::thrift::compiler::detail

--- a/thrift/compiler/sema/check_initializer.cc
+++ b/thrift/compiler/sema/check_initializer.cc
@@ -198,6 +198,7 @@ class compatibility_checker {
       case t_primitive_type::type::t_float:
         return check_float<float>(value, type);
     }
+    abort();
   }
 
   bool check_enum(const t_enum* type, const t_const_value* value) {
@@ -407,6 +408,7 @@ class default_value_checker final {
         // Should never be called for void
         throw std::logic_error("t_void does not have a default value.");
     }
+    abort();
   }
 
   static bool check_enum(const t_const_value& value) {

--- a/thrift/compiler/sema/check_map_keys.cc
+++ b/thrift/compiler/sema/check_map_keys.cc
@@ -73,6 +73,7 @@ std::string to_string(const t_const_value* val) {
     case t_const_value::CV_MAP:
       return to_string(val->get_map());
   }
+  abort();
 }
 
 bool equal_value(const t_const_value* a, const t_const_value* b);
@@ -118,6 +119,7 @@ bool equal_value(const t_const_value* a, const t_const_value* b) {
     case t_const_value::CV_MAP:
       return equal_value(a->get_map(), b->get_map());
   }
+  abort();
 }
 
 bool lt_value(const t_const_value* a, const t_const_value* b);
@@ -164,6 +166,7 @@ bool lt_value(const t_const_value* a, const t_const_value* b) {
     case t_const_value::CV_MAP:
       return lt_value(a->get_map(), b->get_map());
   }
+  abort();
 }
 
 struct const_value_comp {

--- a/thrift/compiler/sema/schematizer.cc
+++ b/thrift/compiler/sema/schematizer.cc
@@ -72,6 +72,7 @@ t_type::value_type from_const_value_type(
     case t_const_value::t_const_value_kind::CV_IDENTIFIER:
       return t_type::value_type::STRING;
   }
+  abort();
 }
 } // namespace
 
@@ -780,6 +781,7 @@ const char* protocol_value_type_name(t_type::value_type ty) {
     case t_type::value_type::MAP:
       return "mapValue";
   }
+  abort();
 }
 
 protocol_value_builder::protocol_value_builder(const t_type& struct_ty)

--- a/thrift/compiler/sema/standard_validator.cc
+++ b/thrift/compiler/sema/standard_validator.cc
@@ -669,6 +669,7 @@ std::string_view field_qualifier_to_string(t_field_qualifier qualifier) {
     case t_field_qualifier::terse:
       return "terse";
   }
+  abort();
 }
 
 void validate_field_default_value(sema_context& ctx, const t_field& field) {

--- a/thrift/compiler/whisker/ast.cc
+++ b/thrift/compiler/whisker/ast.cc
@@ -115,6 +115,7 @@ std::string_view pragma_statement::to_string() const {
     case pragma_statement::pragmas::ignore_newlines:
       return "ignore-newlines";
   }
+  abort();
 }
 
 } // namespace whisker::ast


### PR DESCRIPTION
Currently, GCC warns about code that switches on an enum, but despite handling all enumerations, will not return a value in the default case.

    thrift/compiler/sema/check_map_keys.cc: In function 'bool apache::thrift::compiler::{anonymous}::lt_value(const apache::thrift::compiler::t_const_value*, const apache::thrift::compiler::t_const_value*)':
    thrift/compiler/sema/check_map_keys.cc:167:1: warning: control reaches end of non-void function [-Wreturn-type]
      167 | }
          | ^

This change adds `abort()` after each of these switch statement, the same approach as used e.g. in `t_const_value::kind_to_string`.