### PR TITLE
BinaryProtocol: Optimize reading/writing of fundamental lists on aarch64

### DIFF
--- a/thrift/lib/cpp2/protocol/BinaryProtocol.cpp
+++ b/thrift/lib/cpp2/protocol/BinaryProtocol.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +19,12 @@
 
 #include <folly/Conv.h>
 #include <folly/portability/GFlags.h>
+#include <functional>
+#include <type_traits>
+
+#if defined(__ARM_NEON) && __ARM_NEON
+  #include <arm_neon.h>
+#endif
 
 FOLLY_GFLAGS_DEFINE_int32(
     thrift_cpp2_protocol_reader_string_limit,
@@ -44,6 +51,180 @@ namespace apache::thrift {
           "No version identifier... old protocol client in strict mode? sz=",
           sz));
 }
+
+#define USE_OPTIMIZED_ROUTINES 1
+#if USE_OPTIMIZED_ROUTINES && defined(__ARM_NEON) && __ARM_NEON
+#define COPY_REVERSE_USE_LDP 1
+/**
+ * Reverses the byte ordering for elements of any fundamental type in a 128b input vector.
+ * E.g., a vector of LE-encoded int32_t will be transformed to BE-encoded int32_t
+ * @tparam T type of the elements to reverse byte order for
+ * @param a input vector
+ * @return transformed output vector
+ */
+template<typename T>
+inline uint8x16_t vrevq_generic_u8(uint8x16_t a) {
+    if constexpr (sizeof(T) == 1) {
+      return a; // identity -> byte representation identical on LE and BE
+    } else if constexpr (sizeof(T) == 2) {
+      return vrev16q_u8(a);
+    } else if constexpr (sizeof(T) == 4) {
+      return vrev32q_u8(a);
+    } else if constexpr (sizeof(T) == 8) {
+      return vrev64q_u8(a);
+    } else {
+      static_assert(!std::is_same_v<T, T>, "Unknown element size"); // C++23: static_assert(false); (P2593)
+    }
+}
+
+/**
+ * Copies a contiguous array of fundamental values to another, non overlapping, array while reversing the
+ * byte ordering of the values
+ * @tparam T Type of the elements to copy
+ * @param dsts Destination pointer
+ * @param srcs Source pointer
+ * @param lens Number of elements to copy
+ */
+template <typename T>
+inline std::enable_if_t<std::is_fundamental_v<T>, void> copyReverse(T* dsts, T* srcs, size_t lens) {
+  auto* dst = (uint8_t*) dsts;
+  auto* src = (uint8_t*) srcs;
+
+  size_t len = lens * sizeof(T);
+  // iterate over chunks of 64 bytes
+  while(len >= 64) {
+#if COPY_REVERSE_USE_LDP
+    // Both GCC 13 and LLVM 17 transform this sequence to two ldp instruction and two stp at -O2
+    // first block that loads 32B, reverses byte order, and stores results
+    uint8x16_t  v0 = vld1q_u8(src);
+    uint8x16_t  v1 = vld1q_u8(src + 16);
+    v0 = vrevq_generic_u8<T>(v0);
+    v1 = vrevq_generic_u8<T>(v1);
+    vst1q_u8(dst, v0);
+    vst1q_u8(dst + 16, v1);
+    // second block that loads 32B, reverses byte order, and stores results
+    uint8x16_t  v2 = vld1q_u8(src + 32);
+    uint8x16_t  v3 = vld1q_u8(src + 48);
+    v2 = vrevq_generic_u8<T>(v2);
+    v3 = vrevq_generic_u8<T>(v3);
+    vst1q_u8(dst + 32, v2);
+    vst1q_u8(dst + 48, v3);
+#else
+    // Perform a single 4-reg load & store
+    uint8x16x4_t v0 = vld1q_u8_x4(src);
+    v0.val[0] = vrevq_generic_u8<T>(v0.val[0]);
+    v0.val[1] = vrevq_generic_u8<T>(v0.val[1]);
+    v0.val[2] = vrevq_generic_u8<T>(v0.val[2]);
+    v0.val[3] = vrevq_generic_u8<T>(v0.val[3]);
+    vst1q_u8_x4(dst, v0);
+#endif
+
+    // adjust pointers
+    src += 64;
+    dst += 64;
+    len -= 64;
+  }
+  // copy single chunk of 32 bytes
+  if(len >= 32) {
+    uint8x16_t  v0 = vld1q_u8(src);
+    uint8x16_t  v1 = vld1q_u8(src + 16);
+    v0 = vrevq_generic_u8<T>(v0);
+    v1 = vrevq_generic_u8<T>(v1);
+    vst1q_u8(dst, v0);
+    vst1q_u8(dst + 16, v1);
+    // adjust pointers
+    src += 32;
+    dst += 32;
+    len -= 32;
+  }
+  // copy single chunk of 16 bytes
+  if(len >= 16) {
+    uint8x16_t  v0 = vld1q_u8(src);
+    v0 = vrevq_generic_u8<T>(v0);
+    vst1q_u8(dst, v0);
+    // adjust pointers
+    src += 16;
+    dst += 16;
+    len -= 16;
+  }
+
+  // copy remainder sequentially
+  dsts = (T*) dst;
+  srcs = (T*) src;
+  for(int i = 0; i < len/sizeof(T); ++i) {
+    dsts[i] = folly::Endian::big(srcs[i]);
+  }
+}
+#else
+template <typename T>
+inline void copyReverse(T* dst, T* src, size_t len) {
+    // fallback implementation, this compiles to vectorized copy with scalar registers on aarch64
+#pragma unroll
+    for(int i = 0; i < len; ++i) {
+      dst[i] = folly::Endian::big(src[i]);
+    }
+}
+#endif
+
+
+
+template <typename T>
+void BinaryProtocolReader::readFundamentalVector(std::vector<T>& output) {
+    size_t len_elements = output.size();
+    size_t len = len_elements * sizeof(T);
+    if (FOLLY_LIKELY(in_.length() >= len)) {
+        copyReverse(&output[0], (T*) in_.data(), len_elements);
+        in_.skip(len);
+        return;
+    }
+    // vector does not fit into a contiguous buffer, read element one-by-one
+    for(auto& el : output) {
+      el = in_.readBE<T>();
+    }
+}
+
+template
+void BinaryProtocolReader::readFundamentalVector(std::vector<int64_t>& output);
+template
+void BinaryProtocolReader::readFundamentalVector(std::vector<int32_t>& output);
+template
+void BinaryProtocolReader::readFundamentalVector(std::vector<int16_t>& output);
+template
+void BinaryProtocolReader::readFundamentalVector(std::vector<int8_t>& output);
+template
+void BinaryProtocolReader::readFundamentalVector(std::vector<float>& output);
+template
+void BinaryProtocolReader::readFundamentalVector(std::vector<double>& output);
+
+template <typename T>
+inline size_t BinaryProtocolWriter::writeFundamentalVector(const std::vector<T>& input) {
+  size_t len_elements = input.size();
+  size_t len = len_elements * sizeof(T);
+  out_.ensure(len);
+  if (FOLLY_LIKELY(out_.length() >= len)) {
+    copyReverse( (T*) out_.writableData(), (T*)  &input[0], len_elements);
+    out_.append(len);
+    return len;
+  }
+  // vector does not fit into output buffer, write out one-by-one
+  for(const auto& el : input) {
+    out_.writeBE(el);
+  }
+  return len;
+}
+
+template
+size_t BinaryProtocolWriter::writeFundamentalVector(const std::vector<int64_t>& output);
+template
+size_t BinaryProtocolWriter::writeFundamentalVector(const std::vector<int32_t>& output);
+template
+size_t BinaryProtocolWriter::writeFundamentalVector(const std::vector<int16_t>& output);
+template
+size_t BinaryProtocolWriter::writeFundamentalVector(const std::vector<int8_t>& output);
+template
+size_t BinaryProtocolWriter::writeFundamentalVector(const std::vector<float>& output);
+template
+size_t BinaryProtocolWriter::writeFundamentalVector(const std::vector<double>& output);
 
 void BinaryProtocolReader::skip(TType type, int depth) {
   if (depth >= FLAGS_thrift_protocol_max_depth) {

--- a/thrift/lib/cpp2/protocol/BinaryProtocol.h
+++ b/thrift/lib/cpp2/protocol/BinaryProtocol.h
@@ -24,7 +24,7 @@
 #include <folly/portability/GFlags.h>
 #include <thrift/lib/cpp/protocol/TProtocol.h>
 #include <thrift/lib/cpp2/protocol/Protocol.h>
-
+#include <vector>
 FOLLY_GFLAGS_DECLARE_int32(thrift_cpp2_protocol_reader_string_limit);
 FOLLY_GFLAGS_DECLARE_int32(thrift_cpp2_protocol_reader_container_limit);
 
@@ -62,6 +62,8 @@ class BinaryProtocolWriter : public detail::ProtocolBase {
 
   static constexpr bool kHasIndexSupport() { return true; }
 
+  static constexpr bool kSupportsFundamentalVectors() { return true; }
+
   /**
    * ...
    * The IOBuf itself is managed by the caller.
@@ -98,6 +100,8 @@ class BinaryProtocolWriter : public detail::ProtocolBase {
   uint32_t writeI16(int16_t i16);
   uint32_t writeI32(int32_t i32);
   uint32_t writeI64(int64_t i64);
+  template <typename T>
+  size_t writeFundamentalVector(const std::vector<T>& input);
   uint32_t writeDouble(double dub);
   uint32_t writeFloat(float flt);
   uint32_t writeString(folly::StringPiece str);
@@ -204,6 +208,8 @@ class BinaryProtocolReader : public detail::ProtocolBase {
 
   static constexpr bool kHasDeferredRead() { return false; }
 
+  static constexpr bool kSupportsFundamentalVectors() { return true; }
+
   void setStringSizeLimit(int32_t string_limit) {
     string_limit_ = string_limit;
   }
@@ -245,6 +251,8 @@ class BinaryProtocolReader : public detail::ProtocolBase {
   void readI16(int16_t& i16);
   void readI32(int32_t& i32);
   void readI64(int64_t& i64);
+  template <typename T>
+  void readFundamentalVector(std::vector<T>& output);
   void readDouble(double& dub);
   void readFloat(float& flt);
   template <typename StrType>

--- a/thrift/lib/cpp2/protocol/Protocol.h
+++ b/thrift/lib/cpp2/protocol/Protocol.h
@@ -52,6 +52,7 @@ FOLLY_GFLAGS_DECLARE_int32(thrift_protocol_max_depth);
 namespace apache::thrift {
 
 class BinaryProtocolReader;
+class BinaryProtocolWriter;
 
 namespace detail {
 

--- a/thrift/lib/cpp2/protocol/detail/protocol_methods.h
+++ b/thrift/lib/cpp2/protocol/detail/protocol_methods.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -594,18 +595,25 @@ struct protocol_methods<type_class::list<ElemClass>, Type> {
         // resizeWithoutInitialization first, then resize.
         if constexpr (should_resize_without_initialization) {
           folly::resizeWithoutInitialization(out, list_size);
-          auto outIt = out.begin();
-          const auto outEnd = out.end();
-          try {
-            for (; outIt != outEnd; ++outIt) {
-              elem_methods::read(protocol, *outIt);
+          // Check if we can do a fast path (memcpy that reverses byte order) instead of processing elements sequentially
+          if constexpr (std::is_fundamental_v<elem_type>
+                  && has_kSupportsFundamentalVectors<Protocol>::value) {
+            protocol.readFundamentalVector(out);
+          } else {
+            // fallback: process element by element
+            auto outIt = out.begin();
+            const auto outEnd = out.end();
+            try {
+		          for (; outIt != outEnd; ++outIt) {
+			          elem_methods::read(protocol, *outIt);
+		          }
+            } catch (...) {
+              // For behaviour parity, initialize the leftover elements when
+              // exceptions happen
+              std::fill(outIt, outEnd, elem_type());
+              throw;
             }
-          } catch (...) {
-            // For behaviour parity, initialize the leftover elements when
-            // exceptions happen
-            std::fill(outIt, outEnd, elem_type());
-            throw;
-          }
+	        }
         } else if constexpr (should_resize) {
           out.resize(list_size);
           for (auto&& elem : out) {
@@ -627,6 +635,13 @@ struct protocol_methods<type_class::list<ElemClass>, Type> {
     read(protocol, out);
   }
 
+  template <typename Protocol, typename = void>
+  struct has_kSupportsFundamentalVectors : std::false_type {};
+
+  template <typename Protocol>
+  struct has_kSupportsFundamentalVectors<Protocol, std::void_t<decltype(Protocol::kSupportsFundamentalVectors())>>
+          : std::bool_constant<Protocol::kSupportsFundamentalVectors()> {};
+
   template <typename Protocol>
   static std::size_t write(Protocol& protocol, const Type& out) {
     std::size_t xfer = 0;
@@ -634,8 +649,15 @@ struct protocol_methods<type_class::list<ElemClass>, Type> {
     xfer += protocol.writeListBegin(
         elem_ttype::value, checked_container_size(out.size()));
 
-    for (const auto& elem : out) {
-      xfer += elem_methods::write(protocol, elem);
+    if constexpr (std::is_fundamental_v<elem_type>
+        && has_kSupportsFundamentalVectors<Protocol>::value) {
+      if (out.size() > 0) {
+        xfer += protocol.template writeFundamentalVector<elem_type>(out);
+      }
+    } else {
+      for (const auto& elem : out) {
+        xfer += elem_methods::write(protocol, elem);
+      }
     }
     xfer += protocol.writeListEnd();
     return xfer;

--- a/thrift/lib/cpp2/test/ProtocolBench.cpp
+++ b/thrift/lib/cpp2/test/ProtocolBench.cpp
@@ -175,7 +175,12 @@ constexpr SerializerMethod getSerializerMethod(std::string_view prefix) {
   X2(Prefix, proto, MixedInt)           \
   X2(Prefix, proto, LargeMixed)         \
   X2(Prefix, proto, SmallListInt)       \
+  X2(Prefix, proto, BigListByte)        \
+  X2(Prefix, proto, BigListShort)       \
   X2(Prefix, proto, BigListInt)         \
+  X2(Prefix, proto, BigListBigInt)      \
+  X2(Prefix, proto, BigListFloat)       \
+  X2(Prefix, proto, BigListDouble)      \
   X2(Prefix, proto, BigListMixed)       \
   X2(Prefix, proto, BigListMixedInt)    \
   X2(Prefix, proto, LargeListMixed)     \
@@ -183,7 +188,7 @@ constexpr SerializerMethod getSerializerMethod(std::string_view prefix) {
   X2(Prefix, proto, UnorderedSetInt)    \
   X2(Prefix, proto, SortedVecSetInt)    \
   X2(Prefix, proto, LargeMapInt)        \
-  X2(Prefix, proto, LargeMapMixed)        \
+  X2(Prefix, proto, LargeMapMixed)      \
   X2(Prefix, proto, LargeUnorderedMapMixed)        \
   X2(Prefix, proto, LargeSortedVecMapMixed)        \
   X2(Prefix, proto, UnorderedMapInt)    \
@@ -199,7 +204,7 @@ constexpr SerializerMethod getSerializerMethod(std::string_view prefix) {
   OpEncodeX2(Prefix, proto, BigString)          \
   OpEncodeX2(Prefix, proto, Mixed)              \
   OpEncodeX2(Prefix, proto, MixedInt)           \
-  OpEncodeX2(Prefix, proto, LargeMixed)           \
+  OpEncodeX2(Prefix, proto, LargeMixed)         \
   OpEncodeX2(Prefix, proto, SmallListInt)       \
   OpEncodeX2(Prefix, proto, BigListInt)         \
   OpEncodeX2(Prefix, proto, BigListMixed)       \
@@ -209,7 +214,7 @@ constexpr SerializerMethod getSerializerMethod(std::string_view prefix) {
   OpEncodeX2(Prefix, proto, UnorderedSetInt)    \
   OpEncodeX2(Prefix, proto, SortedVecSetInt)    \
   OpEncodeX2(Prefix, proto, LargeMapInt)        \
-  OpEncodeX2(Prefix, proto, LargeMapMixed)        \
+  OpEncodeX2(Prefix, proto, LargeMapMixed)      \
   OpEncodeX2(Prefix, proto, LargeUnorderedMapMixed)        \
   OpEncodeX2(Prefix, proto, LargeSortedVecMapMixed)        \
   OpEncodeX2(Prefix, proto, UnorderedMapInt)    \

--- a/thrift/lib/cpp2/test/ProtocolBenchData.thrift
+++ b/thrift/lib/cpp2/test/ProtocolBenchData.thrift
@@ -60,8 +60,28 @@ struct SmallListInt {
   1: list<i32> lst;
 }
 
+struct BigListByte {
+  1: list<byte> lst;
+}
+
+struct BigListShort {
+  1: list<i16> lst;
+}
+
 struct BigListInt {
   1: list<i32> lst;
+}
+
+struct BigListBigInt {
+  1: list<i64> lst;
+}
+
+struct BigListFloat {
+  1: list<float> lst;
+}
+
+struct BigListDouble {
+  1: list<double> lst;
 }
 
 struct BigListMixed {

--- a/thrift/lib/cpp2/test/ThriftStructs-inl.h
+++ b/thrift/lib/cpp2/test/ThriftStructs-inl.h
@@ -134,8 +134,9 @@ template <class T>
 inline T createList(int size) {
   std::mt19937 rng;
   T d;
-  while (size-- != 0) {
-    d.lst()->push_back(rng());
+  d.lst()->resize(size);
+  for(int i = 0; i < size; ++i) {
+    d.lst()->at(i) = rng();
   }
   return d;
 }
@@ -153,6 +154,16 @@ create<thrift::benchmark::OpSmallListInt>() {
 }
 
 template <>
+inline thrift::benchmark::BigListByte create<thrift::benchmark::BigListByte>() {
+  return createList<thrift::benchmark::BigListByte>(10000);
+}
+
+template <>
+inline thrift::benchmark::BigListShort create<thrift::benchmark::BigListShort>() {
+  return createList<thrift::benchmark::BigListShort>(10000);
+}
+
+template <>
 inline thrift::benchmark::BigListInt create<thrift::benchmark::BigListInt>() {
   return createList<thrift::benchmark::BigListInt>(10000);
 }
@@ -161,6 +172,19 @@ template <>
 inline thrift::benchmark::OpBigListInt
 create<thrift::benchmark::OpBigListInt>() {
   return createList<thrift::benchmark::OpBigListInt>(10000);
+}
+
+template <>
+inline thrift::benchmark::BigListBigInt create<thrift::benchmark::BigListBigInt>() {
+  return createList<thrift::benchmark::BigListBigInt>(10000);
+}
+template <>
+inline thrift::benchmark::BigListFloat create<thrift::benchmark::BigListFloat>() {
+  return createList<thrift::benchmark::BigListFloat>(10000);
+}
+template <>
+inline thrift::benchmark::BigListDouble create<thrift::benchmark::BigListDouble>() {
+  return createList<thrift::benchmark::BigListDouble>(10000);
 }
 
 template <>


### PR DESCRIPTION
This pull request introduces significant optimizations for reading and writing vectors of fundamental values (integer and floating types) in the BinaryProtocol for ARM. Previously, each vector element was processed individually, involving repeated checks for buffer capacity, potential buffer fetching, value reading, and buffer tail adjustments. This approach incurred substantial overhead and prevented vectorization.

To address this, we've replaced the existing method with a memcpy-like operation that reverses the byte order for each vector element (converting from Little Endian to Big Endian) that is copied. A naive implementation did not achieve optimal performance on the ARM Neoverse-V2 core, as it only generated scalar ldp and stp instructions. Using vector ldp and stp instructions doubles the theoretical throughput.

To overcome this limitation, we've implemented a custom solution utilizing NEON intrinsics, which yields almost optimal performance for large input vectors. This enhancement results in a remarkable speedup of approximately 140x for writing Byte vectors and 18x for I64 vectors. Importantly, no performance regression is introduced for small vectors. If the NEON implementation is not used, the fallback implementation still gives a reasonable speedup.

Contributed by NVIDIA