### PR TITLE
Enable `/bigobj` for `compiler_generators` on Windows

### DIFF
--- a/thrift/compiler/generate/CMakeLists.txt
+++ b/thrift/compiler/generate/CMakeLists.txt
@@ -45,6 +45,10 @@ add_library(compiler_generators STATIC ${GENERATOR_FILES}
             ${CMAKE_CURRENT_BINARY_DIR}/templates.cc)
 set_target_properties(compiler_generators PROPERTIES
                       POSITION_INDEPENDENT_CODE "${BUILD_SHARED_LIBS}")
+if(MSVC)
+  set_target_properties(compiler_generators PROPERTIES
+                        COMPILE_FLAGS "/bigobj")
+endif()
 target_link_libraries(
   compiler_generators
   compiler_ast


### PR DESCRIPTION
When building `fbthrift` statically on Windows, I encountered the following error. Enabling this flag on Windows should help resolve the issue.

```
FAILED: thrift/compiler/generate/CMakeFiles/compiler_generators.dir/t_mstch_rust_generator.cc.obj 
C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1443~1.348\bin\Hostx64\x64\cl.exe   /TP -DTHRIFT_HAVE_LIBSNAPPY=0 -ID:\b\fbthrift\src\5.03.24.00-6181d269be.clean\. -ID:\b\fbthrift\x64-windows-static-dbg -external:ID:\installed\x64-windows-static\include -external:W0 /nologo /DWIN32 /D_WINDOWS /utf-8 /GR /EHsc /MP  /MTd /Z7 /Ob0 /Od /RTC1  -std:c++17 /utf-8 /showIncludes /Fothrift\compiler\generate\CMakeFiles\compiler_generators.dir\t_mstch_rust_generator.cc.obj /Fdthrift\compiler\generate\CMakeFiles\compiler_generators.dir\compiler_generators.pdb /FS -c D:\b\fbthrift\src\5.03.24.00-6181d269be.clean\thrift\compiler\generate\t_mstch_rust_generator.cc
D:\b\fbthrift\src\5.03.24.00-6181d269be.clean\thrift\compiler\generate\t_mstch_rust_generator.cc : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
[105/384] C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1443~1.348\bin\Hostx64\x64\cl.exe   /TP -DTHRIFT_HAVE_LIBSNAPPY=0 -ID:\b\fbthrift\src\5.03.24.00-6181d269be.clean\. -ID:\b\fbthrift\x64-windows-static-dbg -external:ID:\installed\x64-windows-static\include -external:W0 /nologo /DWIN32 /D_WINDOWS /utf-8 /GR /EHsc /MP  /MTd /Z7 /Ob0 /Od /RTC1  -std:c++17 /utf-8 /showIncludes /Fothrift\compiler\generate\CMakeFiles\compiler_generators.dir\t_mstch_cpp2_generator.cc.obj /Fdthrift\compiler\generate\CMakeFiles\compiler_generators.dir\compiler_generators.pdb /FS -c D:\b\fbthrift\src\5.03.24.00-6181d269be.clean\thrift\compiler\generate\t_mstch_cpp2_generator.cc
FAILED: thrift/compiler/generate/CMakeFiles/compiler_generators.dir/t_mstch_cpp2_generator.cc.obj 
C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1443~1.348\bin\Hostx64\x64\cl.exe   /TP -DTHRIFT_HAVE_LIBSNAPPY=0 -ID:\b\fbthrift\src\5.03.24.00-6181d269be.clean\. -ID:\b\fbthrift\x64-windows-static-dbg -external:ID:\installed\x64-windows-static\include -external:W0 /nologo /DWIN32 /D_WINDOWS /utf-8 /GR /EHsc /MP  /MTd /Z7 /Ob0 /Od /RTC1  -std:c++17 /utf-8 /showIncludes /Fothrift\compiler\generate\CMakeFiles\compiler_generators.dir\t_mstch_cpp2_generator.cc.obj /Fdthrift\compiler\generate\CMakeFiles\compiler_generators.dir\compiler_generators.pdb /FS -c D:\b\fbthrift\src\5.03.24.00-6181d269be.clean\thrift\compiler\generate\t_mstch_cpp2_generator.cc
D:\b\fbthrift\src\5.03.24.00-6181d269be.clean\thrift\compiler\generate\t_mstch_cpp2_generator.cc : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
ninja: build stopped: subcommand failed.
```