### PR TITLE
Add ServiceInterceptorQualifiedName.cpp to listfile

### DIFF
--- a/thrift/lib/cpp2/CMakeLists.txt
+++ b/thrift/lib/cpp2/CMakeLists.txt
@@ -288,6 +288,7 @@ add_library(
   server/ServerInstrumentation.cpp
   server/ServiceHealthPoller.cpp
   server/ServiceInterceptorBase.cpp
+  server/ServiceInterceptorQualifiedName.cpp
   server/ThriftProcessor.cpp
   server/ThriftServer.cpp
   server/ThriftServerConfig.cpp


### PR DESCRIPTION
This was added in D73136906 but is missing from CMakeLists.txt.

Spotted via https://github.com/facebook/mcrouter/pull/463:

```
/usr/bin/ld: /home/runner/work/mcrouter/mcrouter/mcrouter-install/install/lib/libthriftcpp2.a(ThriftServer.cpp.o): in function `apache::thrift::ThriftServer::processModulesSpecification(apache::thrift::ThriftServer::ModulesSpecification&&)::ServiceInterceptorsCollector::addModule(apache::thrift::ThriftServer::ModulesSpecification::Info const&)':
ThriftServer.cpp:(.text+0x1d1c3): undefined reference to `apache::thrift::ServiceInterceptorQualifiedName::get() const'
```