### PR TITLE
Fix find_package(FBThrift) failure

### DIFF
--- a/thrift/CMakeLists.txt
+++ b/thrift/CMakeLists.txt
@@ -38,6 +38,11 @@ install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/FBThriftConfig.cmake
   DESTINATION ${CMAKE_INSTALL_DIR}
 )
+# This is used in FBThriftConfig.cmake.
+install(
+  FILES ${CMAKE_CURRENT_SOURCE_DIR}/../build/fbcode_builder/CMake/FindXxhash.cmake
+  DESTINATION ${CMAKE_INSTALL_DIR}
+)
 install(
   EXPORT fbthrift-exports
   FILE FBThriftTargets.cmake

--- a/thrift/cmake/FBThriftConfig.cmake.in
+++ b/thrift/cmake/FBThriftConfig.cmake.in
@@ -29,7 +29,16 @@ else()
   set_and_check(FBTHRIFT_COMPILER "@PACKAGE_BIN_INSTALL_DIR@/thrift1")
 endif()
 
+# Use bundled FindXxhash.cmake to find xxHash.
+if (DEFINED CMAKE_MODULE_PATH)
+  set(FBTHRIFT_CMAKE_MODULE_PATH_OLD ${CMAKE_MODULE_PATH})
+else()
+  set(FBTHRIFT_CMAKE_MODULE_PATH_OLD)
+endif()
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(Xxhash REQUIRED)
+set(CMAKE_MODULE_PATH ${FBTHRIFT_CMAKE_MODULE_PATH_OLD})
+
 find_dependency(ZLIB REQUIRED)
 find_package(mvfst CONFIG REQUIRED)
 


### PR DESCRIPTION
https://github.com/facebook/fbthrift/commit/a6e835df4c83e1be07ba08520b39113be210439e added `find_dependency(Xxhash REQUIRED)`. It uses our `build/fbcode_builder/CMake/FindXxhash.cmake` but our `FindXxhash.cmake` isn't installed. So `find_dependency(Xxhash REQUIRED)` is failed when `xxHash/xxHashConfig.cmake` isn't installed by xxHash.

For example, xxHash package in CentOS 9 stream doesn't install `xxHash/xxHashConfig.cmake`.

See also: https://github.com/facebookincubator/velox/issues/13153

We can fix this by install our `FindXxhash.cmake` and use it in `FBThriftConfig.cmake`.