### PR TITLE
Some AES functions may panic when overflow checking is enabled in ring

### DIFF
--- a/thrift/lib/rust/deterministic_hash/Cargo.toml
+++ b/thrift/lib/rust/deterministic_hash/Cargo.toml
@@ -12,5 +12,5 @@ publish = false
 [dependencies]
 anyhow = "1.0.95"
 fbthrift = { version = "0.0.1+unstable", path = ".." }
-ring = "0.16.20"
+ring = "0.17.12"
 thiserror = "2"


### PR DESCRIPTION
ring::aead::quic::HeaderProtectionKey::new_mask() may panic when overflow checking is enabled. In the QUIC protocol, an attacker can induce this panic by sending a specially-crafted packet. Even unintentionally it is likely to occur in 1 out of every 2**32 packets sent and/or received.

On 64-bit targets operations using ring::aead::{AES_128_GCM, AES_256_GCM} may panic when overflow checking is enabled, when encrypting/decrypting approximately 68,719,476,700 bytes (about 64 gigabytes) of data in a single chunk. Protocols like TLS and SSH are not affected by this because those protocols break large amounts of data into small chunks. Similarly, most applications will not attempt to encrypt/decrypt 64GB of data in one chunk.

Overflow checking is not enabled in release mode by default, but RUSTFLAGS="-C overflow-checks" or overflow-checks = true in the Cargo.toml profile can override this. Overflow checking is usually enabled by default in debug mode.