### PR TITLE
Upgrade commons-io:commons-io from 2.11.0 to 2.19.0

### DIFF
--- a/thrift/lib/java/fbthrift-maven-plugin/pom.xml
+++ b/thrift/lib/java/fbthrift-maven-plugin/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
+            <version>2.19.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
created this PR to upgrade commons-io:commons-io from 2.11.0 to 2.19.0.</h3>

:information_source: Keep your dependencies up-to-date. This makes it easier to fix existing vulnerabilities and to more quickly identify and fix newly disclosed vulnerabilities when they affect your project.

<hr/>


- The recommended version is **10 versions** ahead of your current version.

- The recommended version was released **a month ago**.