### PR TITLE
Upgrade org.apache.maven:maven-plugin-api from 3.8.7 to 3.9.9

### DIFF
--- a/thrift/lib/java/fbthrift-maven-plugin/fbthrift-maven-plugin/pom.xml
+++ b/thrift/lib/java/fbthrift-maven-plugin/fbthrift-maven-plugin/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.8.7</version>
+            <version>3.9.9</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -66,7 +66,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
-                    <mojoDependencies />
+                    <mojoDependencies/>
                     <goalPrefix>thrift</goalPrefix>
                 </configuration>
                 <executions>


### PR DESCRIPTION
PR to upgrade org.apache.maven:maven-plugin-api from 3.8.7 to 3.9.9. ℹ️ Keep your dependencies up-to-date. This makes it easier to fix existing vulnerabilities and to more quickly identify and fix newly disclosed vulnerabilities when they affect your project.