### PR TITLE
Upgrade commons-codec:commons-codec from 1.11 to 1.18.0

### DIFF
--- a/thrift/lib/java/fbthrift-maven-plugin/fbthrift-maven-plugin/pom.xml
+++ b/thrift/lib/java/fbthrift-maven-plugin/fbthrift-maven-plugin/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.11</version>
+            <version>1.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
ℹ️ Keep your dependencies up-to-date. This makes it easier to fix existing vulnerabilities and to more quickly identify and fix newly disclosed vulnerabilities when they affect your project.