### PR TITLE
Upgrade org.slf4j:slf4j-api from 1.7.7 to 1.7.36

### DIFF
--- a/thrift/lib/java/common/pom.xml
+++ b/thrift/lib/java/common/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.7</version>
+      <version>1.7.36</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
upgrade org.slf4j:slf4j-api from 1.7.7 to 1.7.36.
ℹ️ Keep your dependencies up-to-date. This makes it easier to fix existing vulnerabilities and to more quickly identify and fix newly disclosed vulnerabilities when they affect your project.