### PR TITLE
Fix OSS build

### DIFF
--- a/thrift/compiler/CMakeLists.txt
+++ b/thrift/compiler/CMakeLists.txt
@@ -141,8 +141,9 @@ target_link_libraries(
 add_library(
   compiler
 
-  generate/cpp/reference_type.cc
   generate/cpp/name_resolver.cc
+  generate/cpp/orderable_type_utils.cc
+  generate/cpp/reference_type.cc
   generate/cpp/util.cc
   generate/go/util.cc
   generate/java/util.cc


### PR DESCRIPTION
added orderable_type_utils.cc to the compiler target in thrift/compiler/CMakeLists.txt.

This file was introduced in 621ca879973ab204bac530490ae575c906ed0807.