### PR TITLE
Add missing "#include <algorithm>" for std::find_if

### DIFF
--- a/thrift/lib/cpp2/server/DecoratorDataRuntime.h
+++ b/thrift/lib/cpp2/server/DecoratorDataRuntime.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <vector>
 #include <thrift/lib/cpp2/server/DecoratorData.h>
 #include <thrift/lib/cpp2/server/DecoratorDataKey.h>


### PR DESCRIPTION
`thrift/lib/cpp2/server/DecoratorDataRuntime.h` uses `std::find_if` but `algorithm` isn't included.

This causes the following error with g++ 14.3.0:

    FAILED: thrift/lib/cpp2/CMakeFiles/thriftcpp2.dir/server/DecoratorDataRuntime.cpp.o ...
    In file included from thrift/lib/cpp2/server/DecoratorDataRuntime.cpp:17:
    thrift/lib/cpp2/server/DecoratorDataRuntime.h: In member function 'apache::thrift::server::DecoratorDataHandle<T> apache::thrift::server::DecoratorDataHandleFactory::makeHandleForKey(const apache::thrift::server::DecoratorDataKey<T>&)':
    thrift/lib/cpp2/server/DecoratorDataRuntime.h:32:24: error: 'find_if' is not a member of 'std'; did you mean 'find'?
       32 |     if (auto it = std::find_if(
          |                        ^~~~~~~
          |                        find