### PR TITLE
feat(oss): Get thriftpy3 compiling in OSS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(CMAKE_MODULE_PATH
 # Find required dependencies.
 find_package(Boost REQUIRED filesystem)
 find_package(fmt CONFIG REQUIRED)
+find_package(folly CONFIG REQUIRED)
 find_package(OpenSSL REQUIRED)
 
 if(NOT CMAKE_CXX_STANDARD)
@@ -93,8 +94,6 @@ option(thriftpy3
   "Include thrift-py3 library and extensions in the build, requires Cython"
   OFF
 )
-
-find_package(folly CONFIG REQUIRED)
 
 # Find required dependencies for the Thrift compiler.
 if (THRIFT_COMPILER_ONLY OR build_all)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,11 +67,13 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   message(STATUS "setting C++ standard to C++${CMAKE_CXX_STANDARD}")
 endif()
+set(FBTHRIFT_CXX_OPTIONS "-std=c++${CMAKE_CXX_STANDARD}")
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Explicitly enable coroutine support, since GCC does not enable it
 # by default when targeting C++17.
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(FBTHRIFT_CXX_OPTIONS "${FBTHRIFT_CXX_OPTIONS} -fcoroutines")
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fcoroutines>)
 endif()
 

--- a/build/fbcode_builder/CMake/FBPythonWrapper.cmake
+++ b/build/fbcode_builder/CMake/FBPythonWrapper.cmake
@@ -1,0 +1,68 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+function(_write_manifest MANIFEST_FILE PY_TARGET EGG_NAME)
+  set(egg_glob "${CMAKE_INSTALL_PREFIX}/lib/python*/site-packages/${EGG_NAME}-*.egg")
+
+  add_dependencies("${PY_TARGET}" "${MANIFEST_FILE}")
+  set("${PY_TARGET}" INTERFACE_INCLUDE_DIRECTORIES ${MANIFEST_FILE})
+  set("${PY_TARGET}" INTERFACE_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib")
+
+  set(_install_code [[
+    file(GLOB _egg_root @egg_glob@)
+    file(GLOB_RECURSE _egg_files
+      LIST_DIRECTORIES false
+      "${_egg_root}/*"
+    )
+
+    set(_manifest_path "@MANIFEST_FILE@")
+
+    set(_manifest_contents "FBPY_MANIFEST 1\n")
+
+    foreach(_absfile IN LISTS _egg_files)
+      cmake_path(RELATIVE_PATH _absfile BASE_DIRECTORY ${_egg_root} OUTPUT_VARIABLE _egg_relative)
+
+      cmake_path(RELATIVE_PATH _absfile BASE_DIRECTORY ${CMAKE_INSTALL_PREFIX} OUTPUT_VARIABLE _manifest_relative)
+      set("${PY_TARGET}" INTERFACE_SOURCES $_absfile)
+      if(NOT ${_egg_relative} MATCHES "^EGG-INFO/")
+        string(APPEND _manifest_contents "${_manifest_relative} :: ${_egg_relative}\n")
+      endif()
+    endforeach()
+
+    file(WRITE ${_manifest_path} ${_manifest_contents})
+  ]])
+  string(CONFIGURE "${_install_code}" _install_code @ONLY)
+  install(CODE "${_install_code}" DESTINATION ${MANIFEST_FILE} EXPORT)
+endfunction()
+
+function(wrap_non_fb_python_library TARGET EGG_NAME)
+  set(py_lib "${TARGET}.py_lib")
+  add_library("${py_lib}" INTERFACE)
+  install(TARGETS "${py_lib}" EXPORT)
+
+  set(manifest_filename "${TARGET}.manifest")
+  set(build_manifest "${CMAKE_CURRENT_BINARY_DIR}/${manifest_filename}")
+  set(install_manifest "${CMAKE_INSTALL_PREFIX}/${manifest_filename}")
+  target_include_directories(
+    "${py_lib}" INTERFACE
+    "$<BUILD_INTERFACE:${build_manifest}>"
+    "$<INSTALL_INTERFACE:${install_manifest}>"
+  )
+
+  _write_manifest("${install_manifest}" "${py_lib}" "${EGG_NAME}")
+
+  set(build_install_dir "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.lib_install")
+  set(build_install_manifest "${build_install_dir}/${manifest_filename}")
+  add_custom_command(
+    OUTPUT
+      "${build_install_manifest}"
+    COMMAND false
+    DEPENDS
+      "${install_manifest}"
+  )
+  add_custom_target(
+    "${TARGET}.py_lib_install"
+    DEPENDS "${build_install_manifest}"
+  )
+
+  # FIXME: do we need the logic from FBPythonBinary:543-553?
+endfunction()

--- a/thrift/lib/CMakeLists.txt
+++ b/thrift/lib/CMakeLists.txt
@@ -112,10 +112,6 @@ if(thriftpy3)
 
   add_custom_target(create_binding_symlink_python ALL)
   file(GLOB BindingFiles
-    "python/abstract_types.py"
-    "python/client/client_wrapper.py"
-    "python/client/__init__.py"
-    "python/metadata.py"
     "python/client/async_client_factory.pxd"
     "python/client/async_client.pxd"
     "python/client/omni_client.pxd"
@@ -139,6 +135,7 @@ if(thriftpy3)
     "python/stream.pxd"
     "python/types.pxd"
     "python/util.pxd"
+
     "python/adapter.pyx"
     "python/client/async_client_factory.pyx"
     "python/client/async_client.pyx"
@@ -159,15 +156,22 @@ if(thriftpy3)
     "python/mutable_types.pyx"
     "python/protocol.pyx"
     "python/serializer.pyx"
-    "python/stream.pyx"
     "python/server/server.pyx"
+    "python/stream.pyx"
     "python/util.pyx"
+
+    "python/abstract_types.py"
+    "python/client/__init__.py"
+    "python/client/client_wrapper.py"
+    "python/metadata.py"
+
     "python/flags.h"
-    "python/types.h"
     "python/Serializer.h"
+    "python/types.h"
+
+    "python/server/flagged/EnableResourcePoolsForPython.cpp"
     "python/server/PythonAsyncProcessor.cpp"
     "python/server/PythonAsyncProcessorFactory.cpp"
-    "python/server/flagged/EnableResourcePoolsForPython.cpp"
   )
 
   foreach(_src ${BindingFiles})

--- a/thrift/lib/CMakeLists.txt
+++ b/thrift/lib/CMakeLists.txt
@@ -26,11 +26,17 @@ if(thriftpy)
 endif()
 
 if(thriftpy3)
+  include(FBPythonWrapper)
+  find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+
   set(_cybld "${CMAKE_CURRENT_BINARY_DIR}/cybld")
   file(MAKE_DIRECTORY "${_cybld}/thrift/python/")
   file(MAKE_DIRECTORY "${_cybld}/thrift/python/client/")
   file(MAKE_DIRECTORY "${_cybld}/thrift/python/server/")
   file(MAKE_DIRECTORY "${_cybld}/thrift/python/server/flagged/")
+  file(MAKE_DIRECTORY "${_cybld}/thrift/python/server_impl/")
+  file(MAKE_DIRECTORY "${_cybld}/thrift/python/server_impl/interceptor/")
+  file(MAKE_DIRECTORY "${_cybld}/thrift/python/streaming/")
   file(MAKE_DIRECTORY "${_cybld}/thrift/py3/")
 
   # So that cython includes work correctly
@@ -110,6 +116,8 @@ if(thriftpy3)
       ${CMAKE_COMMAND} -E create_symlink "${_cybld}/thrift/python/server/server.pyx" "${_cybld}/thrift/python/server.pyx"
   )
 
+  ########################################################################
+  # Symlink files that get mapped directly
   add_custom_target(create_binding_symlink_python ALL)
   file(GLOB BindingFiles
     "python/client/async_client_factory.pxd"
@@ -133,6 +141,10 @@ if(thriftpy3)
     "python/server/server.pxd"
     "python/std_libcpp.pxd"
     "python/stream.pxd"
+    "python/streaming/py_promise.pxd"
+    "python/streaming/python_user_exception.pxd"
+    "python/streaming/sink.pxd"
+    "python/streaming/stream.pxd"
     "python/types.pxd"
     "python/util.pxd"
 
@@ -156,8 +168,13 @@ if(thriftpy3)
     "python/mutable_types.pyx"
     "python/protocol.pyx"
     "python/serializer.pyx"
+    "python/server/request_context.pyx"
     "python/server/server.pyx"
     "python/stream.pyx"
+    "python/streaming/py_promise.pyx"
+    "python/streaming/python_user_exception.pyx"
+    "python/streaming/sink.pyx"
+    "python/streaming/stream.pyx"
     "python/util.pyx"
 
     "python/abstract_types.py"
@@ -169,14 +186,15 @@ if(thriftpy3)
     "python/Serializer.h"
     "python/types.h"
 
-    "python/server/flagged/EnableResourcePoolsForPython.cpp"
     "python/server/PythonAsyncProcessor.cpp"
     "python/server/PythonAsyncProcessorFactory.cpp"
+    "python/streaming/PythonUserException.cpp"
+    "python/streaming/Sink.cpp"
+    "python/streaming/StreamElementEncoder.cpp"
   )
 
   foreach(_src ${BindingFiles})
     file(RELATIVE_PATH _filerelpath ${CMAKE_CURRENT_SOURCE_DIR} ${_src})
-    get_filename_component(_target_file "${_src}" NAME)
 
     message(
       STATUS
@@ -192,6 +210,40 @@ if(thriftpy3)
     )
   endforeach()
 
+
+  ########################################################################
+  # Symlink files that get mapped server -> server_impl
+  file(GLOB BindingFiles
+    "python/server/async_processor.pxd"
+    "python/server/event_handler.pxd"
+    "python/server/interceptor/server_module.pxd"
+    "python/server/python_async_processor.pxd"
+    "python/server/request_context.pxd"
+
+    "python/server/python_async_processor.pyx"
+
+    "python/server/PythonAsyncProcessor.cpp"
+    "python/server/PythonAsyncProcessorFactory.cpp"
+  )
+  foreach(_src ${BindingFiles})
+    file(RELATIVE_PATH _filerelpath ${CMAKE_CURRENT_SOURCE_DIR}/python/server ${_src})
+
+    message(
+      STATUS
+      "Linking ${_src} to ${_cybld}/thrift/python/server_impl/${_filerelpath}"
+    )
+
+    add_custom_command(
+      TARGET
+      create_binding_symlink_python
+      PRE_BUILD
+        COMMAND
+        ${CMAKE_COMMAND} -E create_symlink "${_src}" "${_cybld}/thrift/python/server_impl/${_filerelpath}"
+    )
+  endforeach()
+
+  ########################################################################
+  # Symlink all the py3 files
   add_custom_target(create_binding_symlink_py3 ALL)
   file(GLOB BindingFiles
     "${CMAKE_CURRENT_SOURCE_DIR}/py3/*.pxd"
@@ -227,16 +279,28 @@ if(thriftpy3)
       thriftcpp2
     WORKING_DIRECTORY ${_cybld}
   )
+
+  set(_folly_site_packages "${CMAKE_INSTALL_PREFIX}/../folly/lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages")
+  # FIXME: For some reason, FOLLY_VERSION is not defined
+  set(_folly_version "0.0.1")
+  set(_folly_PYTHONPATH "${_folly_site_packages}/folly-${_folly_version}-py${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}-linux-x86_64.egg")
+  
   add_custom_command(TARGET thrift_python_types_bindings
     COMMAND ${CMAKE_COMMAND} -E env
-      "CFLAGS=${CMAKE_C_FLAGS}"
-      "CXXFLAGS=${CMAKE_CXX_FLAGS}"
+      "CFLAGS=${CMAKE_C_FLAGS} ${FBTHRIFT_CXX_OPTIONS}"
+      "CXXFLAGS=${CMAKE_CXX_FLAGS} ${FBTHRIFT_CXX_OPTIONS}"
       "CXX=${CMAKE_CXX_COMPILER}"
-      python3 ${CMAKE_CURRENT_SOURCE_DIR}/setup.py -v --api-only
+      "PYTHONPATH=${_cybld}/lib:${_cybld}:${_folly_PYTHONPATH}:$ENV{PYTHONPATH}"
+      ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py -v --api-only
     BYPRODUCTS
-      ${_cybld}/thrift/python/types_api.h
+      ${_cybld}/thrift/python/_types_api.h
       ${_cybld}/thrift/python/server/server_api.h
-      ${_cybld}/thrift/python/util_api.h
+      ${_cybld}/thrift/python/server_impl/python_async_processor_api.h
+      ${_cybld}/thrift/python/streaming/sink_api.h
+      ${_cybld}/thrift/python/_stream_api.h
+    DEPENDS
+      ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
+      # FIXME: add .pxd/.pyx files here
     WORKING_DIRECTORY ${_cybld}
   )
 
@@ -247,6 +311,7 @@ if(thriftpy3)
     WORKING_DIRECTORY ${_cybld})
   file(MAKE_DIRECTORY "${_cybld}/thrift/lib/python/")
   file(MAKE_DIRECTORY "${_cybld}/thrift/lib/python/server")
+  file(MAKE_DIRECTORY "${_cybld}/thrift/lib/python/streaming")
   file(MAKE_DIRECTORY "${_cybld}/thrift/lib/py3/")
 
   add_custom_command(
@@ -271,13 +336,13 @@ if(thriftpy3)
     TARGET
     create_cython_types_api_symlink
       COMMAND
-      ${CMAKE_COMMAND} -E create_symlink "${_cybld}/thrift/python/_util_api.h" "${_cybld}/thrift/lib/python/util_api.h"
+      ${CMAKE_COMMAND} -E create_symlink "${_cybld}/thrift/python/server_impl/python_async_processor_api.h" "${_cybld}/thrift/lib/python/server/python_async_processor_api.h"
   )
   add_custom_command(
     TARGET
     create_cython_types_api_symlink
       COMMAND
-      ${CMAKE_COMMAND} -E create_symlink "${_cybld}/thrift/python/_util.h" "${_cybld}/thrift/lib/python/_util.h"
+      ${CMAKE_COMMAND} -E create_symlink "${_cybld}/thrift/python/streaming/sink_api.h" "${_cybld}/thrift/lib/python/streaming/sink_api.h"
   )
   add_custom_command(
     TARGET
@@ -296,8 +361,9 @@ if(thriftpy3)
       python/client/OmniClient.cpp
       python/client/RequestChannel.cpp
       python/client/ssl.cpp
+      python/streaming/PythonUserException.cpp
+      python/streaming/StreamElementEncoder.cpp
       python/types.cpp
-      python/util.cpp
       python/Serializer.cpp
       py3/stream.cpp
   )
@@ -306,20 +372,32 @@ if(thriftpy3)
   target_compile_definitions(thrift_python_cpp PRIVATE BOOST_NO_AUTO_PTR)
   target_compile_definitions(thrift_python_cpp PRIVATE THRIFT_NO_HTTP_CLIENT_CHANNEL)
   target_include_directories(thrift_python_cpp PRIVATE "${_cybld}")
+  target_include_directories(thrift_python_cpp PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+  target_include_directories(thrift_python_cpp PRIVATE Folly::folly_python_cpp)
   target_link_libraries(
     thrift_python_cpp
     PUBLIC
       thriftcpp2
       Folly::folly
       Folly::folly_python_cpp
+    PRIVATE
+      Python3::Python
     )
   install(
     TARGETS thrift_python_cpp
-    EXPORT thrift
+    EXPORT fbthrift-exports
+    # FIXME: Consider DESTINATION ${LIB_INSTALL_DIR}
   )
   install(
     TARGETS thrift_python_cpp
     DESTINATION ${py_install_dir}
+  )
+
+  wrap_non_fb_python_library(thrift_python_cpp thrift)
+  install(
+    TARGETS thrift_python_cpp.py_lib
+    EXPORT fbthrift-exports
+    DESTINATION ${LIB_INSTALL_DIR}
   )
 
   #####
@@ -332,8 +410,10 @@ if(thriftpy3)
       generate_apache_thrift_metadata_python
       create_binding_symlink_python
       create_binding_symlink_py3
+      Folly::folly_python_cpp
       thriftcpp2
       thrift_python_cpp
+      thrift_python_types_bindings
     WORKING_DIRECTORY ${_cybld}
   )
 
@@ -357,29 +437,38 @@ if(thriftpy3)
 
   add_custom_command(TARGET thrift_python_and_py3_bindings
     COMMAND ${CMAKE_COMMAND} -E env
-      "CFLAGS=${CMAKE_C_FLAGS}"
-      "CXXFLAGS=${CMAKE_CXX_FLAGS}"
+      "CFLAGS=${CMAKE_C_FLAGS} ${FBTHRIFT_CXX_OPTIONS}"
+      "CXXFLAGS=${CMAKE_CXX_FLAGS} ${FBTHRIFT_CXX_OPTIONS}"
       "CXX=${CMAKE_CXX_COMPILER}"
+      "PYTHONPATH=${_cybld}/lib:${_cybld}:${_folly_PYTHONPATH}:$ENV{PYTHONPATH}"
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/setup.py -v
       build_ext -f ${incs} ${libs} --libpython ${python_libname}
+    DEPENDS
+      ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
     WORKING_DIRECTORY ${_cybld}
   )
   add_custom_command(TARGET thrift_python_and_py3_bindings
     COMMAND ${CMAKE_COMMAND} -E env
-      "CFLAGS=${CMAKE_C_FLAGS}"
-      "CXXFLAGS=${CMAKE_CXX_FLAGS}"
+      "CFLAGS=${CMAKE_C_FLAGS} ${FBTHRIFT_CXX_OPTIONS}"
+      "CXXFLAGS=${CMAKE_CXX_FLAGS} ${FBTHRIFT_CXX_OPTIONS}"
       "CXX=${CMAKE_CXX_COMPILER}"
+      "PYTHONPATH=${_cybld}/lib:${_cybld}:${_folly_PYTHONPATH}:$ENV{PYTHONPATH}"
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/setup.py -v
       bdist_wheel --libpython ${python_libname}
+    DEPENDS
+      ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
     WORKING_DIRECTORY ${_cybld}
   )
   add_custom_command(TARGET thrift_python_and_py3_bindings POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E env
-      "CFLAGS=${CMAKE_C_FLAGS}"
-      "CXXFLAGS=${CMAKE_CXX_FLAGS}"
+      "CFLAGS=${CMAKE_C_FLAGS} ${FBTHRIFT_CXX_OPTIONS}"
+      "CXXFLAGS=${CMAKE_CXX_FLAGS} ${FBTHRIFT_CXX_OPTIONS}"
       "CXX=${CMAKE_CXX_COMPILER}"
+      "PYTHONPATH=${_cybld}/lib:${_cybld}:${_folly_PYTHONPATH}:$ENV{PYTHONPATH}"
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/setup.py -v
       install --prefix ${CMAKE_INSTALL_PREFIX} --libpython ${python_libname}
+    DEPENDS
+      ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
     WORKING_DIRECTORY ${_cybld}
   )
 
@@ -390,8 +479,8 @@ if(thriftpy3)
   install(CODE "
     execute_process(
       COMMAND ${CMAKE_COMMAND} -E env
-        \"CFLAGS=${CMAKE_C_FLAGS}\"
-        \"CXXFLAGS=${CMAKE_CXX_FLAGS}\"
+        \"CFLAGS=${CMAKE_C_FLAGS} ${FBTHRIFT_CXX_OPTIONS}\"
+        \"CXXFLAGS=${CMAKE_CXX_FLAGS} ${FBTHRIFT_CXX_OPTIONS}\"
         python3 ${CMAKE_CURRENT_SOURCE_DIR}/setup.py install -v
         --prefix ${py_install_dir} --libpython ${python_libname}
       COMMAND_ECHO STDOUT

--- a/thrift/lib/python/server/python_async_processor.pxd
+++ b/thrift/lib/python/server/python_async_processor.pxd
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cimport cython
 from cpython.ref cimport PyObject
 from libcpp cimport bool as cbool
 from libcpp.map cimport map as cmap
@@ -20,21 +21,40 @@ from libcpp.pair cimport pair
 from libcpp.string cimport string
 from libcpp.vector cimport vector as cvector
 
+from folly cimport cFollyPromise, cFollyUnit, c_unit
 from folly.executor cimport cAsyncioExecutor
 from folly.iobuf cimport cIOBuf
 
-from thrift.python.exceptions cimport cException
+from thrift.py3.stream cimport (
+    cResponseAndServerStream,
+    cServerStream,
+    ServerStream,
+)
+from thrift.python.exceptions cimport (
+    cException,
+    cTApplicationException,
+)
 from thrift.python.protocol cimport RpcKind
 from thrift.python.server_impl.async_processor cimport (
     cAsyncProcessorFactory,
     AsyncProcessorFactory,
 )
+from thrift.python.streaming.py_promise cimport Promise_Py
+from thrift.python.streaming.python_user_exception cimport cPythonUserException
+from thrift.python.streaming.sink cimport (
+    cResponseAndSinkConsumer,
+    cSinkConsumer,
+)
 from thrift.python.types cimport ServiceInterface as cServiceInterface
+
 
 # cython doesn't support * in template parameters
 # Make a typedef to workaround this.
 ctypedef PyObject* PyObjPtr
 
+ctypedef unique_ptr[cIOBuf] UniqueIOBuf
+ctypedef cResponseAndSinkConsumer[UniqueIOBuf, UniqueIOBuf, UniqueIOBuf] SinkResponse
+ctypedef cResponseAndServerStream[UniqueIOBuf, UniqueIOBuf] StreamResponse
 
 
 cdef extern from "thrift/lib/python/server/PythonAsyncProcessorFactory.h" namespace "::apache::thrift::python":
@@ -60,3 +80,58 @@ cdef class PythonAsyncProcessorFactory(AsyncProcessorFactory):
 
     @staticmethod
     cdef PythonAsyncProcessorFactory create(cServiceInterface server)
+
+cdef class Promise_cFollyUnit(Promise_Py):
+    cdef cFollyPromise[cFollyUnit]* cPromise
+
+    cdef error_ta(Promise_cFollyUnit self, cTApplicationException err)
+    cdef error_py(Promise_cFollyUnit self, cPythonUserException err)
+    cdef complete(Promise_cFollyUnit self, object _)
+
+    @staticmethod
+    cdef create(cFollyPromise[cFollyUnit] cPromise)
+
+cdef class Promise_Sink(Promise_Py):
+    cdef cFollyPromise[SinkResponse]* _cPromise
+
+    cdef error_ta(Promise_Sink self, cTApplicationException err)
+    cdef error_py(Promise_Sink self, cPythonUserException err)
+    cdef complete(Promise_Sink self, object pyobj)
+    
+    @staticmethod
+    cdef create(cFollyPromise[SinkResponse] promise)
+
+cdef class Promise_Stream(Promise_Py):
+    cdef cFollyPromise[StreamResponse]* cPromise
+
+    cdef error_ta(Promise_Stream self, cTApplicationException err)
+    cdef error_py(Promise_Stream self, cPythonUserException err)
+    cdef complete(Promise_Stream self, object pyobj)
+    
+    @staticmethod
+    cdef create(cFollyPromise[StreamResponse] cPromise)
+    
+cdef class ResponseAndServerStream:
+    cdef unique_ptr[StreamResponse] cResponseStream
+
+    @staticmethod
+    cdef _fbthrift_create(object val, object stream)
+
+cdef class ResponseAndSinkConsumer:
+    cdef unique_ptr[SinkResponse] _cResponseSink
+    
+    @staticmethod
+    cdef _fbthrift_create(object val, object sink)
+
+@cython.final
+cdef class ServerSink_IOBuf:
+    cdef unique_ptr[cSinkConsumer[UniqueIOBuf, UniqueIOBuf]] _cSink
+    
+    @staticmethod
+    cdef _fbthrift_create(object sink_callback)
+
+cdef class ServerStream_IOBuf(ServerStream):
+    cdef unique_ptr[cServerStream[UniqueIOBuf]] cStream
+
+    @staticmethod
+    cdef _fbthrift_create(object stream)

--- a/thrift/lib/python/server/python_async_processor.pxd
+++ b/thrift/lib/python/server/python_async_processor.pxd
@@ -13,22 +13,23 @@
 # limitations under the License.
 
 from cpython.ref cimport PyObject
-from libcpp.memory cimport unique_ptr
-from libcpp.string cimport string
+from libcpp cimport bool as cbool
 from libcpp.map cimport map as cmap
+from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.pair cimport pair
+from libcpp.string cimport string
 from libcpp.vector cimport vector as cvector
+
+from folly.executor cimport cAsyncioExecutor
 from folly.iobuf cimport cIOBuf
+
+from thrift.python.exceptions cimport cException
 from thrift.python.protocol cimport RpcKind
-from thrift.python.types cimport ServiceInterface as cServiceInterface
 from thrift.python.server_impl.async_processor cimport (
     cAsyncProcessorFactory,
     AsyncProcessorFactory,
 )
-from thrift.python.exceptions cimport cException
-from libcpp.memory cimport shared_ptr
-from libcpp cimport bool as cbool
-from folly.executor cimport cAsyncioExecutor
+from thrift.python.types cimport ServiceInterface as cServiceInterface
 
 # cython doesn't support * in template parameters
 # Make a typedef to workaround this.

--- a/thrift/lib/python/server/python_async_processor.pyx
+++ b/thrift/lib/python/server/python_async_processor.pyx
@@ -16,11 +16,8 @@ import asyncio
 import sys
 import traceback
 
-from thrift.python.serializer import serialize_iobuf
-from thrift.python.types import ServiceInterface
-
-cimport cython
 from cpython.ref cimport PyObject
+cimport cython
 from cython.operator cimport dereference
 from libcpp.map cimport map as cmap
 from libcpp.memory cimport make_unique, make_shared, static_pointer_cast
@@ -33,21 +30,7 @@ from libcpp.vector cimport vector as cvector
 from folly cimport cFollyPromise, cFollyUnit, c_unit
 from folly.executor cimport get_executor
 from folly.iobuf cimport IOBuf, from_unique_ptr
-from thrift.python.exceptions cimport (
-    ApplicationError,
-    cTApplicationException,
-    cTApplicationExceptionType__UNKNOWN,
-)
-from thrift.python.server_impl.request_context cimport (
-    Cpp2RequestContext,
-    handleAddressCallback,
-    RequestContext,
-    THRIFT_REQUEST_CONTEXT,
-)
-from thrift.python.server_impl.request_context import (
-    RequestContext,
-    SocketAddress,
-)
+
 from thrift.py3.stream cimport (
     cServerStream,
     cResponseAndServerStream,
@@ -55,8 +38,20 @@ from thrift.py3.stream cimport (
     createAsyncIteratorFromPyIterator,
     ServerStream
 )
-from thrift.python.types cimport ServiceInterface as cServiceInterface
+from thrift.python.exceptions cimport (
+    ApplicationError,
+    cTApplicationException,
+    cTApplicationExceptionType__UNKNOWN,
+)
 from thrift.python.protocol cimport Protocol
+from thrift.python.serializer import serialize_iobuf
+from thrift.python.server_impl.request_context cimport (
+    Cpp2RequestContext,
+    handleAddressCallback,
+    RequestContext,
+    SocketAddress,
+    THRIFT_REQUEST_CONTEXT,
+)
 from thrift.python.streaming.py_promise cimport (
     Promise_IOBuf,
     Promise_Optional_IOBuf,
@@ -73,6 +68,7 @@ from thrift.python.streaming.sink cimport (
     cSinkConsumer,
     makeIOBufSinkConsumer,
 )
+from thrift.python.types cimport ServiceInterface as cServiceInterface
 
 
 ctypedef unique_ptr[cIOBuf] UniqueIOBuf

--- a/thrift/lib/python/streaming/py_promise.pxd
+++ b/thrift/lib/python/streaming/py_promise.pxd
@@ -49,4 +49,4 @@ cdef class Promise_IOBuf(Promise_Py):
 
 
 cdef void genNextStreamValue(object generator, cFollyPromise[optional[unique_ptr[cIOBuf]]] promise) noexcept
-cdef void genNextSinkValue(object generator, cFollyPromise[optional[unique_ptr[cIOBuf]]] promise) noexcept
+cdef api void genNextSinkValue(object generator, cFollyPromise[optional[unique_ptr[cIOBuf]]] promise) noexcept

--- a/thrift/lib/python/streaming/py_promise.pxd
+++ b/thrift/lib/python/streaming/py_promise.pxd
@@ -17,8 +17,10 @@ from libcpp.optional cimport optional
 
 from folly cimport cFollyPromise
 from folly.iobuf cimport cIOBuf, IOBuf
+
 from thrift.python.exceptions cimport cTApplicationException
 from thrift.python.streaming.python_user_exception cimport cPythonUserException
+
 
 cdef class Promise_Py:
     cdef error_ta(Promise_Py self, cTApplicationException err)

--- a/thrift/lib/python/streaming/py_promise.pyx
+++ b/thrift/lib/python/streaming/py_promise.pyx
@@ -18,15 +18,25 @@ import sys
 
 from cpython cimport bool as pbool
 from cython.operator cimport dereference
+from libcpp.memory cimport unique_ptr
+from libcpp.optional cimport optional
 from libcpp.utility cimport move as cmove
 
-from folly.iobuf cimport IOBuf
+from folly cimport cFollyPromise
+from folly.iobuf cimport (
+    IOBuf,
+    cIOBuf,
+)
 
 from thrift.python.exceptions cimport (
     ApplicationError,
+    cTApplicationException,
     cTApplicationExceptionType__UNKNOWN,
 )
-from thrift.python.streaming.python_user_exception cimport PythonUserException
+from thrift.python.streaming.python_user_exception cimport (
+    PythonUserException,
+    cPythonUserException,
+)
 
 
 cdef class Promise_Py:
@@ -146,7 +156,7 @@ cdef void genNextStreamValue(object generator, cFollyPromise[optional[unique_ptr
         )
     )
 
-cdef void genNextSinkValue(object generator, cFollyPromise[optional[unique_ptr[cIOBuf]]] promise) noexcept:
+cdef api void genNextSinkValue(object generator, cFollyPromise[optional[unique_ptr[cIOBuf]]] promise) noexcept:
     cdef Promise_Optional_IOBuf __promise = Promise_Optional_IOBuf.create(cmove(promise))
     asyncio.get_event_loop().create_task(
         runGenerator(

--- a/thrift/lib/python/streaming/py_promise.pyx
+++ b/thrift/lib/python/streaming/py_promise.pyx
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cpython cimport bool as pbool
-from cython.operator cimport dereference
-from libcpp.utility cimport move as cmove
-
 import asyncio
 import traceback
 import sys
 
+from cpython cimport bool as pbool
+from cython.operator cimport dereference
+from libcpp.utility cimport move as cmove
+
 from folly.iobuf cimport IOBuf
+
 from thrift.python.exceptions cimport (
     ApplicationError,
     cTApplicationExceptionType__UNKNOWN,

--- a/thrift/lib/python/streaming/python_user_exception.pyx
+++ b/thrift/lib/python/streaming/python_user_exception.pyx
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from thrift.python.streaming.python_user_exception cimport cPythonUserException
+
 from cython.operator cimport dereference as deref
-from libcpp.memory cimport make_unique
+from libcpp.memory cimport make_unique, unique_ptr
 from libcpp.string cimport string
 from libcpp.utility cimport move as cmove
 
-from folly.iobuf cimport from_unique_ptr
+from folly cimport cFollyExceptionWrapper
+from folly.iobuf cimport IOBuf, cIOBuf, from_unique_ptr
 
 
 cdef class PythonUserException(Exception):

--- a/thrift/lib/python/streaming/python_user_exception.pyx
+++ b/thrift/lib/python/streaming/python_user_exception.pyx
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from cython.operator cimport dereference as deref
+from libcpp.memory cimport make_unique
 from libcpp.string cimport string
 from libcpp.utility cimport move as cmove
-from libcpp.memory cimport make_unique
 
 from folly.iobuf cimport from_unique_ptr
 

--- a/thrift/lib/python/streaming/sink.pxd
+++ b/thrift/lib/python/streaming/sink.pxd
@@ -129,6 +129,16 @@ cdef class ResponseAndBidirectionalStream:
 cdef class ResponseAndClientSink:
     pass
 
+cdef class ServerSinkGenerator:
+    cdef cIOBufSinkGenerator _cpp_gen
+    cdef cFollyExecutor* _executor
+
+    @staticmethod
+    cdef _fbthrift_create(
+        cIOBufSinkGenerator cpp_gen,
+        cFollyExecutor* executor,
+    )
+
 cdef api void cancelAsyncGenerator(object generator)
 
 cdef api int invoke_server_sink_callback(

--- a/thrift/lib/python/streaming/sink.pxd
+++ b/thrift/lib/python/streaming/sink.pxd
@@ -19,8 +19,10 @@ from folly cimport cFollyExecutor, cFollyPromise
 from folly.async_generator cimport cAsyncGenerator
 from folly.coro cimport cFollyCoroTask
 from folly.iobuf cimport cIOBuf
+
 from thrift.python.protocol cimport Protocol
 from thrift.python.streaming.stream cimport ClientBufferedStream, cIOBufClientBufferedStream
+
 
 cdef extern from "folly/OperationCancelled.h":
     cdef cppclass cFollyOperationCancelled "folly::OperationCancelled"

--- a/thrift/lib/python/streaming/sink.pyx
+++ b/thrift/lib/python/streaming/sink.pyx
@@ -16,6 +16,11 @@ import asyncio
 import sys
 import traceback
 
+from cython.operator import dereference
+from cpython.ref cimport PyObject
+from libcpp.memory cimport make_shared, make_unique, shared_ptr
+from libcpp.utility cimport move as cmove
+
 from folly cimport cFollyPromise, cFollyTry
 from folly.coro cimport (
     bridgeCoroTaskWith,
@@ -24,25 +29,19 @@ from folly.coro cimport (
     cFollyCoroTask,
 )
 from folly.executor cimport get_executor
-
-from cython.operator import dereference
-from cpython.ref cimport PyObject
-from libcpp.memory cimport make_shared, make_unique, shared_ptr
-from libcpp.utility cimport move as cmove
-from thrift.python.serializer import deserialize
-from thrift.python.mutable_serializer import (
-    deserialize as deserialize_mutable,
-)
 from folly.iobuf cimport IOBuf, from_unique_ptr as iobuf_from_unique_ptr
+
 from thrift.python.exceptions cimport (
     ApplicationError,
     cTApplicationException,
     cTApplicationExceptionType__UNKNOWN,
     create_py_exception,
 )
-from thrift.python.types import Struct
+from thrift.python.mutable_serializer import (
+    deserialize as deserialize_mutable,
+)
 from thrift.python.mutable_types import MutableStruct
-
+from thrift.python.serializer import deserialize
 from thrift.python.streaming.py_promise cimport (
     genNextSinkValue,
     Promise_IOBuf,
@@ -53,7 +52,7 @@ from thrift.python.streaming.python_user_exception cimport (
     PythonUserException,
 )
 from thrift.python.streaming.stream cimport cIOBufClientBufferedStream
-
+from thrift.python.types import Struct
 
 
 cdef class ClientSink:

--- a/thrift/lib/python/streaming/sink.pyx
+++ b/thrift/lib/python/streaming/sink.pyx
@@ -18,7 +18,7 @@ import traceback
 
 from cython.operator import dereference
 from cpython.ref cimport PyObject
-from libcpp.memory cimport make_shared, make_unique, shared_ptr
+from libcpp.memory cimport make_shared, make_unique, shared_ptr, unique_ptr
 from libcpp.utility cimport move as cmove
 
 from folly cimport cFollyPromise, cFollyTry
@@ -41,6 +41,7 @@ from thrift.python.mutable_serializer import (
     deserialize as deserialize_mutable,
 )
 from thrift.python.mutable_types import MutableStruct
+from thrift.python.protocol cimport Protocol
 from thrift.python.serializer import deserialize
 from thrift.python.streaming.py_promise cimport (
     genNextSinkValue,
@@ -51,9 +52,9 @@ from thrift.python.streaming.python_user_exception cimport (
     extractPyUserExceptionIOBuf,
     PythonUserException,
 )
+from thrift.python.streaming.sink cimport cIOBufClientSink, cIOBufSinkGenerator
 from thrift.python.streaming.stream cimport cIOBufClientBufferedStream
 from thrift.python.types import Struct
-
 
 cdef class ClientSink:
     @staticmethod
@@ -215,7 +216,7 @@ cdef raise_first_exception_field(response_struct):
 cdef void sink_final_resp_callback(
     cFollyTry[unique_ptr[cIOBuf]]&& res,
     PyObject* user_data,
-):
+) noexcept:
     future, final_resp_cls, sink_elem_cls, protocol = <object> user_data
     try:
         if res.hasException():
@@ -310,9 +311,6 @@ async def invokeCallbackWithGenerator(
 
 
 cdef class ServerSinkGenerator:
-    cdef cIOBufSinkGenerator _cpp_gen
-    cdef cFollyExecutor* _executor
-
     @staticmethod
     cdef _fbthrift_create(
         cIOBufSinkGenerator cpp_gen,

--- a/thrift/lib/python/streaming/stream.pyx
+++ b/thrift/lib/python/streaming/stream.pyx
@@ -22,11 +22,14 @@ from libcpp.utility cimport move as cmove
 from folly cimport cFollyTry
 from folly.coro cimport bridgeCoroTaskWith
 from folly.executor cimport get_executor
-from folly.iobuf cimport from_unique_ptr
+from folly.iobuf cimport cIOBuf, from_unique_ptr
 from folly.optional cimport cOptional
 
 from thrift.python.exceptions cimport create_py_exception
+from thrift.python.protocol cimport Protocol
 from thrift.python.serializer import deserialize
+
+from thrift.python.streaming.stream cimport cIOBufClientBufferedStream
 
 
 cdef void client_stream_callback(

--- a/thrift/lib/setup.py
+++ b/thrift/lib/setup.py
@@ -37,20 +37,8 @@ if "--api-only" in sys.argv:
         language_level=3,
     )
     Cython.Compiler.Main.compile(
-        "thrift/python/server.pyx",
-        full_module_name="thrift.python.server",
-        cplus=True,
-        language_level=3,
-    )
-    Cython.Compiler.Main.compile(
-        "thrift/python/_util.pyx",
-        full_module_name="thrift.python.util",
-        cplus=True,
-        language_level=3,
-    )
-    Cython.Compiler.Main.compile(
-        "thrift/py3/_stream.pyx",
-        full_module_name="thrift.py3.stream",
+        "thrift/python/server_impl/python_async_processor.pyx",
+        full_module_name="thrift.python.server_impl.python_async_processor",
         cplus=True,
         language_level=3,
     )
@@ -85,7 +73,6 @@ else:
     }
 
     exts = [
-        # thrift.python extension modules
         Extension(
             "thrift.python.adapter",
             sources=["thrift/python/adapter.pyx"],
@@ -188,18 +175,40 @@ else:
         ),
         Extension(
             "thrift.python.server",
-            sources=[
-                "thrift/python/server.pyx",
-                "thrift/python/server/PythonAsyncProcessor.cpp",
-                "thrift/python/server/PythonAsyncProcessorFactory.cpp",
-                "thrift/python/server/flagged/EnableResourcePoolsForPython.cpp",
+            sources=["thrift/python/server.pyx"],
+             **common_options,
+         ),
+         Extension(
+             "thrift.python.server_impl.python_async_processor",
+             sources=[
+                 "thrift/python/server_impl/python_async_processor.pyx",
+                 "thrift/python/server_impl/PythonAsyncProcessor.cpp",
+                 "thrift/python/server_impl/PythonAsyncProcessorFactory.cpp",
             ],
             define_macros=[("__PYX_ENUM_CLASS_DECL", "")],
             **common_options,
         ),
         Extension(
-            "thrift.python.stream",
-            sources=["thrift/python/stream.pyx"],
+            "thrift.python.streaming.py_promise",
+            sources=["thrift/python/streaming/py_promise.pyx"],
+            **common_options,
+        ),
+        Extension(
+            "thrift.python.streaming.python_user_exception",
+            sources=["thrift/python/streaming/python_user_exception.pyx"],
+            **common_options,
+        ),
+        Extension(
+            "thrift.python.streaming.sink",
+            sources=[
+                "thrift/python/streaming/sink.pyx",
+                "thrift/python/streaming/Sink.cpp",
+            ],
+            **common_options,
+        ),
+        Extension(
+            "thrift.python.streaming.stream",
+            sources=["thrift/python/streaming/stream.pyx"],
             **common_options,
         ),
         Extension(
@@ -207,12 +216,6 @@ else:
             sources=["thrift/python/_types.pyx"],
             **common_options,
         ),
-        Extension(
-            "thrift.python.util",
-            sources=["thrift/python/_util.pyx"],
-            **common_options,
-        ),
-        # thrift.py3 extension modules
         Extension(
             "thrift.py3.common",
             sources=["thrift/py3/common.pyx"],


### PR DESCRIPTION
NOTE: This change is intended to land after folly PRs 2503-2507
NOTE: The changes to FBPythonWrapper.cmake duplicate those in [folly PR 2505](https://github.com/facebook/folly/pull/2505) which is shared internally between folly and fbthrift.

There are three distinct parts to this change:

1. Updating the build infra necessary to get thriftpy3 compilation working and accessible from sapling/eden
2. Updating the cython files to compile cleanly with Cython 3.0.8-3.1.3. (The internal version of cython appears to have some different rules around declaring/defining classes.)
3. ~Removing the use of the ironically deprecated `#[deprecated]` macro in Rust (may need a better fix)~

~It also fixes the following build error:~
```
| error: `#[deprecated]` attribute cannot be used on extern crates
|    --> /tmp/fbcode_builder_getdeps-ZUsersZbenZossZsaplingZbuildZfbcode_builder-root/build/rust-shed/release/build/just_knobs_struct-7461bc517a178a8c/out/lib.rs:206:5
|     |
| 206 |     #[deprecated = "Please use `//thrift/annotation:rust-rust` directly"]
|     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
|     |
|     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
|     = help: `#[deprecated]` can be applied to functions, data types, modules, unions, constants, statics, macro defs, type aliases, use statements, foreign statics, struct fields, traits, associated types, associated consts, enum variants, inherent impl blocks, and crates
|     = note: `#[deny(useless_deprecated)]` on by default
```

Looking at the individual diffs in the PR should help the reviewer see these changes in context.

Tested by running a clean build of EdenFS in Sapling, which needs to import fbthrift with the thriftpy3 flag enabled.