### PR TITLE
Fix typo in ThriftLibrary.cmake

### DIFF
--- a/ThriftLibrary.cmake
+++ b/ThriftLibrary.cmake
@@ -223,7 +223,7 @@ macro(thrift_generate
     ${output_path}/gen-${language}/${source_file_name}_data.h
     ${output_path}/gen-${language}/${source_file_name}_metadata.h
     ${output_path}/gen-${language}/${source_file_name}_types.h
-    ${output_path}/gen-${language}/${source_file_name}_types.tcch
+    ${output_path}/gen-${language}/${source_file_name}_types.tcc
     ${output_path}/gen-${language}/${source_file_name}_types_custom_protocol.h
   )
   set("${target_file_name}-${language}-SOURCES"


### PR DESCRIPTION
At least I'm pretty sure it's a typo, @vitaut? It was introduced in 58038399cefc0c2256ce4ef5444dee37147cbf07.