### PR TITLE
Fix the `transport` target dependency for static linking

### DIFF
--- a/thrift/lib/cpp/CMakeLists.txt
+++ b/thrift/lib/cpp/CMakeLists.txt
@@ -74,6 +74,16 @@ target_link_libraries(
     concurrency
     thrift-core
     rpcmetadata
+    # We need to link to libthriftcpp2.a after libtransport.a because
+    # libtransport.a uses
+    # apache::thrift::rocket::CompressionManager::uncompressBuffer()
+    # that is defined in libthriftcpp2.a.
+    #
+    # We don't need this for libtransport.so because libthriftcpp2.so
+    # and libtransport.so are cyclic dependencies and libthriftcpp2.so
+    # has libtransport.so dependency. We can't link to
+    # libthriftcpp2.so from libtransport.so. It's not allowed.
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:$<INSTALL_INTERFACE:FBThrift::thriftcpp2>>
     Folly::folly
     ZLIB::ZLIB
     ${OPENSSL_LIBRARIES}


### PR DESCRIPTION
`libtransport` uses
`apache::thrift::rocket::CompressionAlgorithmSelector::fromTTransform()` in `thrift/lib/cpp/transport/THeader.cpp`:

https://github.com/facebook/fbthrift/blob/531d08e0f9af1c17e9cb7fd49ab037a779aee376/thrift/lib/cpp/transport/THeader.cpp#L569-L571

So `libthriftcpp2.a` must be linked after `libtransport.a`.

Note that we don't need it for shared linking. Because `libthriftcpp2.so` already has `libtransport.so` dependency.