### PR TITLE
Avoid unnecessary stores in readVarint on AArch64

### DIFF
--- a/thrift/lib/cpp/util/VarintUtils-inl.h
+++ b/thrift/lib/cpp/util/VarintUtils-inl.h
@@ -139,43 +139,59 @@ size_t readVarintMediumSlowUnrolledX86(T& value, const uint8_t* p) {
 template <class T>
 size_t readVarintMediumSlowUnrolledAarch64(T& result, const uint8_t* p) {
   // clang-format off
+  T tmp_result = 0;
   T byte;
-  byte = *p++; result = (byte & 0x7f);       
-  if (UNLIKELY(!(byte & 0x80))) 
+  byte = *p++; tmp_result = (byte & 0x7f);
+  if (UNLIKELY(!(byte & 0x80))) {
+    result = tmp_result;
     return 1;
-  byte = *p++; result |= (byte & 0x7f) <<  7; 
+  }
+  byte = *p++; tmp_result |= (byte & 0x7f) <<  7;
   if constexpr (sizeof(T) == 1) {
-    if (UNLIKELY((byte & 0x80))) 
+    if (UNLIKELY((byte & 0x80)))
       throwInvalidVarint();
+    result = tmp_result;
     return 2;
   } else {
-    if (UNLIKELY(!(byte & 0x80))) 
+    if (UNLIKELY(!(byte & 0x80))){
+      result = tmp_result;
       return 2;
-    byte = *p++; result |= (byte & 0x7f) << 14;
+    }
+    byte = *p++; tmp_result |= (byte & 0x7f) << 14;
     if constexpr (sizeof(T) == 2) {
-      if (UNLIKELY((byte & 0x80))) 
+      if (UNLIKELY((byte & 0x80)))
         throwInvalidVarint();
+      result = tmp_result;
       return 3;
     } else {
-      if (UNLIKELY(!(byte & 0x80))) 
+      if (UNLIKELY(!(byte & 0x80))){
+        result = tmp_result;
         return 3;
-      byte = *p++; result |= (byte & 0x7f) << 21; 
-      if (UNLIKELY(!(byte & 0x80))) 
+      }
+      byte = *p++; tmp_result |= (byte & 0x7f) << 21;
+      if (UNLIKELY(!(byte & 0x80))) {
+        result = tmp_result;
         return 4;
-      byte = *p++; result |= (byte & 0x7f) << 28;
+      }
+      byte = *p++; tmp_result |= (byte & 0x7f) << 28;
       if constexpr (sizeof(T) == 4) {
-        if (UNLIKELY((byte & 0x80))) 
+        if (UNLIKELY((byte & 0x80)))
           throwInvalidVarint();
+        result = tmp_result;
         return 5;
       } else {
-        if (UNLIKELY(!(byte & 0x80))) return 5;
-        byte = *p++; result |= (byte & 0x7f) << 35; if (UNLIKELY(!(byte & 0x80))) return 6;
-        byte = *p++; result |= (byte & 0x7f) << 42; if (UNLIKELY(!(byte & 0x80))) return 7;
-        byte = *p++; result |= (byte & 0x7f) << 49; if (UNLIKELY(!(byte & 0x80))) return 8;
-        byte = *p++; result |= (byte & 0x7f) << 56; if (UNLIKELY(!(byte & 0x80))) return 9;
-        byte = *p; result |= (byte & 0x7f) << 63; 
-        if (UNLIKELY((byte & 0x80))) 
+        if (UNLIKELY(!(byte & 0x80))) {
+                result = tmp_result;
+                return 5;
+        }
+        byte = *p++; tmp_result |= (byte & 0x7f) << 35; if (UNLIKELY(!(byte & 0x80))) { result = tmp_result; return 6; }
+        byte = *p++; tmp_result |= (byte & 0x7f) << 42; if (UNLIKELY(!(byte & 0x80))) { result = tmp_result; return 7; }
+        byte = *p++; tmp_result |= (byte & 0x7f) << 49; if (UNLIKELY(!(byte & 0x80))) { result = tmp_result; return 8; }
+        byte = *p++; tmp_result |= (byte & 0x7f) << 56; if (UNLIKELY(!(byte & 0x80))) { result = tmp_result; return 9; }
+        byte = *p; tmp_result |= (byte & 0x7f) << 63;
+        if (UNLIKELY((byte & 0x80)))
           throwInvalidVarint();
+        result = tmp_result;
         return 10;
       }
     }


### PR DESCRIPTION
Instead of storing result to memory at each byte iteration, we can keep temp result in a register and only write to memory once at the end. This reduces unnecessary memory stores and improves performance.

Benchmark result without this patch:
============================================================================
[...]hrift/lib/cpp2/test/ProtocolBench.cpp     relative  time/iter   iters/s
============================================================================
CompactProtocol_read_BigListBigInt                         34.46us    29.02K

Benchmark result with this patch:
============================================================================
[...]hrift/lib/cpp2/test/ProtocolBench.cpp     relative  time/iter   iters/s
============================================================================
CompactProtocol_read_BigListBigInt                         30.21us    33.10K

Performance is uplifted by 14%.