### PR TITLE
Use FOLLY_HAS_LIBURING instead of __has_include in SSLUtil

### DIFF
--- a/thrift/lib/cpp2/security/SSLUtil.cpp
+++ b/thrift/lib/cpp2/security/SSLUtil.cpp
@@ -144,7 +144,7 @@ folly::AsyncSocketTransport::UniquePtr toFDSocket(
 
   auto sock = fizzSock->template getUnderlyingTransport<folly::AsyncSocket>();
   folly::AsyncSocketTransport::UniquePtr ret;
-#if defined(__linux__) && __has_include(<liburing.h>)
+#if FOLLY_HAS_LIBURING
   if (!sock &&
       fizzSock->template getUnderlyingTransport<folly::AsyncIoUringSocket>()) {
     // `AsyncFdSocket` currently lacks uring support, so hardcode `AsyncSocket`


### PR DESCRIPTION
## Summary

Fixes #649

`SSLUtil.cpp` was using `#if defined(__linux__) && __has_include(<liburing.h>)` to guard the io_uring code path. This is an ad-hoc check that only tests whether the `liburing.h` header is present on the system, without verifying that Folly was actually compiled with uring support.

This PR replaces it with the `FOLLY_HAS_LIBURING` macro from Folly's feature test header (`folly/io/async/Liburing.h`), which is already available through the existing `<folly/io/async/AsyncIoUringSocketFactory.h>` include. This matches the pattern used consistently throughout the rest of the fbthrift codebase (e.g., `ThriftServer.cpp`, `IOUringUtil.h`, `IOUringUtil.cpp`, and the stresstest utilities).

## Changes

- `thrift/lib/cpp2/security/SSLUtil.cpp`: Replace `#if defined(__linux__) && __has_include(<liburing.h>)` with `#if FOLLY_HAS_LIBURING`

## Verification

- Grepped the full fbthrift codebase: this was the only file using `__has_include(<liburing.h>)` directly. All other uring-related files already use `FOLLY_HAS_LIBURING`.
- No other `__has_include` checks for `<liburing.h>` remain in the codebase.