### PR TITLE
Fix compatibility with fmt 12.2.0

### DIFF
--- a/thrift/common/test/universal_name_test.cc
+++ b/thrift/common/test/universal_name_test.cc
@@ -17,7 +17,7 @@
 #include <thrift/common/universal_name.h>
 
 #include <regex>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/thrift/common/tree_printer.h
+++ b/thrift/common/tree_printer.h
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace apache::thrift::tree_printer {
 

--- a/thrift/common/universal_name.cc
+++ b/thrift/common/universal_name.cc
@@ -19,7 +19,6 @@
 #include <cctype>
 #include <stdexcept>
 #include <boost/container/small_vector.hpp>
-#include <fmt/core.h>
 #include <fmt/format.h>
 
 namespace apache::thrift {

--- a/thrift/compiler/ast/scope_identifier.cc
+++ b/thrift/compiler/ast/scope_identifier.cc
@@ -15,7 +15,7 @@
  */
 
 #include <cassert>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/compiler/ast/scope_identifier.h>
 

--- a/thrift/compiler/ast/t_const.cc
+++ b/thrift/compiler/ast/t_const.cc
@@ -16,7 +16,7 @@
 
 #include <algorithm>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/compiler/ast/t_const.h>
 #include <thrift/compiler/ast/t_const_value.h>
 

--- a/thrift/compiler/ast/t_include.h
+++ b/thrift/compiler/ast/t_include.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/compiler/ast/t_node.h>
 
 namespace apache::thrift::compiler {

--- a/thrift/compiler/ast/t_named.cc
+++ b/thrift/compiler/ast/t_named.cc
@@ -21,7 +21,7 @@
 #include <thrift/compiler/ast/t_type.h>
 #include <thrift/compiler/ast/uri.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace apache::thrift::compiler {
 

--- a/thrift/compiler/ast/t_program.h
+++ b/thrift/compiler/ast/t_program.h
@@ -26,7 +26,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/compiler/ast/node_list.h>
 #include <thrift/compiler/ast/program_scope.h>

--- a/thrift/compiler/ast/thrift_ast_debug_tree_utils.cc
+++ b/thrift/compiler/ast/thrift_ast_debug_tree_utils.cc
@@ -17,7 +17,7 @@
 #include "thrift/compiler/ast/thrift_ast_debug_tree_utils.h"
 
 #include <string>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "thrift/common/tree_printer.h"
 #include "thrift/compiler/ast/t_program_bundle.h"

--- a/thrift/compiler/codemod/annotate_allow_legacy_missing_uris.cc
+++ b/thrift/compiler/codemod/annotate_allow_legacy_missing_uris.cc
@@ -18,7 +18,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 #include <thrift/compiler/ast/ast_visitor.h>
 #include <thrift/compiler/ast/t_program_bundle.h>

--- a/thrift/compiler/codemod/annotate_allow_unsafe_non_sealed_key_type.cc
+++ b/thrift/compiler/codemod/annotate_allow_unsafe_non_sealed_key_type.cc
@@ -16,7 +16,7 @@
 
 #include <optional>
 #include <string_view>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/compiler/ast/ast_visitor.h>
 #include <thrift/compiler/ast/t_map.h>
 #include <thrift/compiler/ast/t_program_bundle.h>

--- a/thrift/compiler/codemod/annotate_custom_default_optional_fields.cc
+++ b/thrift/compiler/codemod/annotate_custom_default_optional_fields.cc
@@ -16,7 +16,7 @@
 
 #include <string>
 #include <string_view>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/compiler/ast/ast_visitor.h>
 #include <thrift/compiler/ast/t_program_bundle.h>
 #include <thrift/compiler/ast/t_struct.h>

--- a/thrift/compiler/codemod/annotate_deprecated_terse_writes_fields.cc
+++ b/thrift/compiler/codemod/annotate_deprecated_terse_writes_fields.cc
@@ -16,7 +16,7 @@
 
 #include <string>
 #include <string_view>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/compiler/ast/ast_visitor.h>
 #include <thrift/compiler/ast/t_program_bundle.h>
 #include <thrift/compiler/ast/t_struct.h>

--- a/thrift/compiler/codemod/annotate_non_optional_cpp_ref_fields.cc
+++ b/thrift/compiler/codemod/annotate_non_optional_cpp_ref_fields.cc
@@ -16,7 +16,7 @@
 
 #include <string>
 #include <string_view>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/compiler/ast/ast_visitor.h>
 #include <thrift/compiler/ast/t_program_bundle.h>
 #include <thrift/compiler/ast/t_struct.h>

--- a/thrift/compiler/codemod/annotate_required_fields.cc
+++ b/thrift/compiler/codemod/annotate_required_fields.cc
@@ -16,7 +16,7 @@
 
 #include <string>
 #include <string_view>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/compiler/ast/ast_visitor.h>
 #include <thrift/compiler/ast/t_program_bundle.h>
 #include <thrift/compiler/ast/t_struct.h>

--- a/thrift/compiler/codemod/codemod.cc
+++ b/thrift/compiler/codemod/codemod.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/compiler/codemod/codemod.h>
 #include <thrift/compiler/compiler.h>
 #include <thrift/compiler/parse/parse_ast.h>

--- a/thrift/compiler/codemod/file_manager.cc
+++ b/thrift/compiler/codemod/file_manager.cc
@@ -15,7 +15,7 @@
  */
 
 #include <string>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 #include <folly/FileUtil.h>
 

--- a/thrift/compiler/codemod/file_manager.h
+++ b/thrift/compiler/codemod/file_manager.h
@@ -20,7 +20,7 @@
 #include <optional>
 #include <set>
 #include <unordered_set>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/FileUtil.h>
 

--- a/thrift/compiler/codemod/migrate_php_namespace_to_hack_name_prefix.cc
+++ b/thrift/compiler/codemod/migrate_php_namespace_to_hack_name_prefix.cc
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/compiler/ast/t_program.h>
 #include <thrift/compiler/ast/t_program_bundle.h>

--- a/thrift/compiler/codemod/package_generator.h
+++ b/thrift/compiler/codemod/package_generator.h
@@ -21,7 +21,6 @@
 #include <utility>
 
 #include <boost/algorithm/string.hpp>
-#include <fmt/core.h>
 #include <fmt/format.h>
 #include <re2/re2.h>
 #include <thrift/compiler/ast/t_program.h>

--- a/thrift/compiler/codemod/relative_include.cc
+++ b/thrift/compiler/codemod/relative_include.cc
@@ -18,7 +18,7 @@
 #include <set>
 #include <string>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/compiler/ast/t_include.h>
 #include <thrift/compiler/ast/t_program.h>
 #include <thrift/compiler/ast/uri.h>

--- a/thrift/compiler/codemod/remove_duplicate_namespaces.cc
+++ b/thrift/compiler/codemod/remove_duplicate_namespaces.cc
@@ -16,7 +16,7 @@
 
 #include <set>
 #include <string>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/compiler/ast/t_program.h>
 #include <thrift/compiler/ast/t_program_bundle.h>
 #include <thrift/compiler/codemod/codemod.h>

--- a/thrift/compiler/codemod/specify_implicit_field_id.cc
+++ b/thrift/compiler/codemod/specify_implicit_field_id.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/compiler/ast/ast_visitor.h>
 #include <thrift/compiler/codemod/codemod.h>

--- a/thrift/compiler/codemod/specify_implicit_func_param_id.cc
+++ b/thrift/compiler/codemod/specify_implicit_func_param_id.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/compiler/ast/ast_visitor.h>
 #include <thrift/compiler/codemod/codemod.h>

--- a/thrift/compiler/codemod/structure_annotations.cc
+++ b/thrift/compiler/codemod/structure_annotations.cc
@@ -16,7 +16,7 @@
 
 #include <string>
 #include <string_view>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <range/v3/view.hpp>
 
 #include <thrift/compiler/ast/ast_visitor.h>

--- a/thrift/compiler/diagnostic.h
+++ b/thrift/compiler/diagnostic.h
@@ -27,7 +27,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <thrift/compiler/detail/pluggable_functions.h>
 #include <thrift/compiler/metrics/metrics.h>

--- a/thrift/compiler/generate/cpp/orderable_type_utils.cc
+++ b/thrift/compiler/generate/cpp/orderable_type_utils.cc
@@ -16,7 +16,7 @@
 
 #include <unordered_set>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/compiler/ast/t_program.h>
 #include <thrift/compiler/ast/t_structured.h>
 #include <thrift/compiler/ast/uri.h>

--- a/thrift/compiler/generate/cpp/util.cc
+++ b/thrift/compiler/generate/cpp/util.cc
@@ -25,7 +25,7 @@
 #include <openssl/evp.h>
 #include <openssl/sha.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/compiler/ast/t_field.h>
 #include <thrift/compiler/ast/t_list.h>

--- a/thrift/compiler/generate/csharp/util.cc
+++ b/thrift/compiler/generate/csharp/util.cc
@@ -16,7 +16,7 @@
 
 #include <thrift/compiler/generate/csharp/util.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/compiler/ast/t_container.h>
 #include <thrift/compiler/ast/t_primitive_type.h>
 #include <thrift/compiler/ast/t_structured.h>

--- a/thrift/compiler/generate/go/util.cc
+++ b/thrift/compiler/generate/go/util.cc
@@ -17,7 +17,7 @@
 #include <cctype>
 #include <utility>
 #include <boost/algorithm/string.hpp>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/compiler/ast/t_type.h>
 #include <thrift/compiler/generate/go/util.h>
 

--- a/thrift/compiler/generate/json.cc
+++ b/thrift/compiler/generate/json.cc
@@ -17,7 +17,7 @@
 #include <thrift/compiler/ast/t_const_value.h>
 #include <thrift/compiler/generate/json.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <cstdint>

--- a/thrift/compiler/generate/schema_populator.cc
+++ b/thrift/compiler/generate/schema_populator.cc
@@ -19,7 +19,7 @@
 #include <string>
 #include <type_traits>
 #include <utility>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/io/IOBuf.h>
 
 #include <thrift/compiler/ast/t_const.h>

--- a/thrift/compiler/generate/t_generator.cc
+++ b/thrift/compiler/generate/t_generator.cc
@@ -19,7 +19,7 @@
 #include <stdexcept>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace apache::thrift::compiler {
 

--- a/thrift/compiler/generate/t_mstch_cpp2_generator.cc
+++ b/thrift/compiler/generate/t_mstch_cpp2_generator.cc
@@ -24,7 +24,7 @@
 #include <vector>
 
 #include <boost/algorithm/string/split.hpp>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/compiler/ast/t_const.h>
 #include <thrift/compiler/ast/t_field.h>

--- a/thrift/compiler/generate/t_mstch_java_generator.cc
+++ b/thrift/compiler/generate/t_mstch_java_generator.cc
@@ -24,7 +24,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <openssl/evp.h>
 #include <thrift/compiler/ast/t_typedef.h>

--- a/thrift/compiler/parse/lexer.h
+++ b/thrift/compiler/parse/lexer.h
@@ -19,7 +19,7 @@
 #include <functional>
 #include <optional>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/compiler/parse/token.h>
 #include <thrift/compiler/source_location.h>

--- a/thrift/compiler/parse/token.cc
+++ b/thrift/compiler/parse/token.cc
@@ -16,7 +16,7 @@
 
 #include <thrift/compiler/parse/token.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <cassert>

--- a/thrift/compiler/sema/schematizer.cc
+++ b/thrift/compiler/sema/schematizer.cc
@@ -19,7 +19,7 @@
 #include <filesystem>
 #include <string>
 #include <string_view>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <openssl/evp.h>
 #include <openssl/md5.h>
 #include <openssl/sha.h>

--- a/thrift/compiler/source_location.cc
+++ b/thrift/compiler/source_location.cc
@@ -17,7 +17,7 @@
 #include <thrift/compiler/detail/system.h>
 #include <thrift/compiler/source_location.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/std.h>
 
 #include <algorithm>

--- a/thrift/compiler/test/token_test.cc
+++ b/thrift/compiler/test/token_test.cc
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 #include <thrift/compiler/parse/token.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using namespace apache::thrift::compiler; // NOLINT
 

--- a/thrift/compiler/whisker/ast.cc
+++ b/thrift/compiler/whisker/ast.cc
@@ -18,7 +18,7 @@
 #include <thrift/compiler/whisker/detail/overload.h>
 #include <thrift/compiler/whisker/detail/string.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <cassert>

--- a/thrift/compiler/whisker/dsl.h
+++ b/thrift/compiler/whisker/dsl.h
@@ -20,7 +20,7 @@
 #include <thrift/compiler/whisker/managed_ptr.h>
 #include <thrift/compiler/whisker/object.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <concepts>

--- a/thrift/compiler/whisker/eval_context.cc
+++ b/thrift/compiler/whisker/eval_context.cc
@@ -20,7 +20,7 @@
 #include <iterator>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace w = whisker::make;
 

--- a/thrift/compiler/whisker/lexer.h
+++ b/thrift/compiler/whisker/lexer.h
@@ -27,7 +27,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace whisker {
 

--- a/thrift/compiler/whisker/object.cc
+++ b/thrift/compiler/whisker/object.cc
@@ -23,7 +23,7 @@
 #include <ostream>
 #include <type_traits>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <boost/core/demangle.hpp>

--- a/thrift/compiler/whisker/object.h
+++ b/thrift/compiler/whisker/object.h
@@ -42,7 +42,7 @@
 #include <thrift/compiler/whisker/source_location.h>
 #include <thrift/compiler/whisker/tree_printer.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <boost/core/demangle.hpp>
 

--- a/thrift/compiler/whisker/parser.cc
+++ b/thrift/compiler/whisker/parser.cc
@@ -20,7 +20,7 @@
 #include <thrift/compiler/whisker/lexer.h>
 #include <thrift/compiler/whisker/parser.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cassert>
 #include <iterator>

--- a/thrift/compiler/whisker/print_ast.cc
+++ b/thrift/compiler/whisker/print_ast.cc
@@ -22,7 +22,7 @@
 #include <concepts>
 #include <ostream>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace whisker {
 

--- a/thrift/compiler/whisker/render.cc
+++ b/thrift/compiler/whisker/render.cc
@@ -32,7 +32,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 namespace whisker {

--- a/thrift/compiler/whisker/standard_library.cc
+++ b/thrift/compiler/whisker/standard_library.cc
@@ -18,7 +18,7 @@
 
 #include <thrift/compiler/whisker/dsl.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <iterator>
 

--- a/thrift/compiler/whisker/test/eval_context_test.cc
+++ b/thrift/compiler/whisker/test/eval_context_test.cc
@@ -19,7 +19,7 @@
 
 #include <thrift/compiler/whisker/eval_context.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace w = whisker::make;
 

--- a/thrift/compiler/whisker/test/lexer_test.cc
+++ b/thrift/compiler/whisker/test/lexer_test.cc
@@ -27,7 +27,7 @@
 #include <string>
 #include <variant>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace whisker {
 

--- a/thrift/compiler/whisker/test/parser_test.cc
+++ b/thrift/compiler/whisker/test/parser_test.cc
@@ -28,7 +28,7 @@
 #include <string>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace whisker {
 

--- a/thrift/compiler/whisker/test/render_test_helpers.h
+++ b/thrift/compiler/whisker/test/render_test_helpers.h
@@ -34,7 +34,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 namespace whisker {

--- a/thrift/compiler/whisker/token.cc
+++ b/thrift/compiler/whisker/token.cc
@@ -24,7 +24,7 @@
 #include <stdexcept>
 #include <type_traits>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 // clang-format off

--- a/thrift/compiler/whisker/token.h
+++ b/thrift/compiler/whisker/token.h
@@ -26,7 +26,7 @@
 #include <unordered_map>
 #include <variant>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace whisker {
 

--- a/thrift/compiler/whisker/tools/ast-check.cc
+++ b/thrift/compiler/whisker/tools/ast-check.cc
@@ -24,7 +24,7 @@
 #include <optional>
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using namespace std::literals;
 

--- a/thrift/compiler/whisker/tools/ast-dump.cc
+++ b/thrift/compiler/whisker/tools/ast-dump.cc
@@ -28,7 +28,7 @@
 #include <string>
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using namespace std::literals;
 

--- a/thrift/conformance/cpp2/Testing.cpp
+++ b/thrift/conformance/cpp2/Testing.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/conformance/cpp2/Testing.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 #include <folly/lang/Exception.h>
 #include <thrift/conformance/if/gen-cpp2/any_constants.h>

--- a/thrift/conformance/cpp2/internal/TestValue.h
+++ b/thrift/conformance/cpp2/internal/TestValue.h
@@ -18,7 +18,7 @@
 
 #include <stdexcept>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Utility.h>
 #include <folly/io/IOBuf.h>
 #include <folly/lang/Exception.h>

--- a/thrift/conformance/data/CompatibilityGenerator.cpp
+++ b/thrift/conformance/data/CompatibilityGenerator.cpp
@@ -24,7 +24,7 @@
 #include <vector>
 
 #include <boost/mp11.hpp>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/container/Foreach.h>
 #include <thrift/conformance/cpp2/Protocol.h>
 #include <thrift/conformance/data/ValueGenerator.h>

--- a/thrift/conformance/data/PatchGenerator.cpp
+++ b/thrift/conformance/data/PatchGenerator.cpp
@@ -23,7 +23,7 @@
 #include <unordered_map>
 #include <thrift/conformance/data/PatchGenerator.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/conformance/data/ValueGenerator.h>
 #include <thrift/lib/cpp/util/SaturatingMath.h>

--- a/thrift/conformance/data/TestGenerator.cpp
+++ b/thrift/conformance/data/TestGenerator.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/conformance/data/TestGenerator.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/conformance/data/TestUtil.h>
 #include <thrift/conformance/data/ValueGenerator.h>

--- a/thrift/conformance/data/ToleranceGenerator.cpp
+++ b/thrift/conformance/data/ToleranceGenerator.cpp
@@ -17,7 +17,7 @@
 #include <thrift/conformance/data/ToleranceGenerator.h>
 
 #include <boost/mp11.hpp>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 #include <thrift/conformance/cpp2/Protocol.h>

--- a/thrift/conformance/data/ValueGenerator.h
+++ b/thrift/conformance/data/ValueGenerator.h
@@ -23,7 +23,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/CPortability.h>
 #include <thrift/lib/cpp2/type/NativeType.h>
 #include <thrift/lib/cpp2/type/Tag.h>

--- a/thrift/conformance/rpcclient/GTestHarnessRPCClient.cpp
+++ b/thrift/conformance/rpcclient/GTestHarnessRPCClient.cpp
@@ -29,7 +29,7 @@ constexpr auto kClientTimeout = std::chrono::seconds(60);
 constexpr auto kClientTimeout = std::chrono::seconds(10);
 #endif
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Subprocess.h>
 #include <folly/coro/AsyncGenerator.h>
 #include <folly/coro/BlockingWait.h>

--- a/thrift/conformance/stresstest/client/TestRunner.cpp
+++ b/thrift/conformance/stresstest/client/TestRunner.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/conformance/stresstest/client/TestRunner.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <gflags/gflags.h>
 
 #include <thrift/conformance/stresstest/client/ClientRunner.h>

--- a/thrift/conformance/stresstest/common/StressTestStats.cpp
+++ b/thrift/conformance/stresstest/common/StressTestStats.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/conformance/stresstest/common/StressTestStats.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 namespace apache::thrift::stress {

--- a/thrift/lib/cpp/protocol/TProtocolException.cpp
+++ b/thrift/lib/cpp/protocol/TProtocolException.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/lib/cpp/protocol/TProtocolException.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace apache::thrift::protocol {
 

--- a/thrift/lib/cpp/protocol/TType.h
+++ b/thrift/lib/cpp/protocol/TType.h
@@ -18,7 +18,7 @@
 
 #include <stdint.h>
 #include <string>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace apache::thrift::protocol {
 

--- a/thrift/lib/cpp/server/test/TrackingTServerEventHandler.cpp
+++ b/thrift/lib/cpp/server/test/TrackingTServerEventHandler.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/lib/cpp/server/test/TrackingTServerEventHandler.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ExceptionString.h>
 
 namespace apache::thrift::server::test {

--- a/thrift/lib/cpp/test/ContextStackFrameworkMetadataTest.cpp
+++ b/thrift/lib/cpp/test/ContextStackFrameworkMetadataTest.cpp
@@ -16,7 +16,7 @@
 
 #include <gtest/gtest.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/lib/cpp/ContextStack.h>
 #include <thrift/lib/cpp2/async/InterceptorFlags.h>
 #include <thrift/lib/cpp2/test/util/TrackingTProcessorEventHandler.h>

--- a/thrift/lib/cpp/transport/THeader.cpp
+++ b/thrift/lib/cpp/transport/THeader.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/lib/cpp/transport/THeader.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Conv.h>
 #include <folly/MapUtil.h>
 #include <folly/String.h>

--- a/thrift/lib/cpp/transport/TTransportException.cpp
+++ b/thrift/lib/cpp/transport/TTransportException.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/lib/cpp/transport/TTransportException.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/String.h>
 

--- a/thrift/lib/cpp/util/THttpParser.cpp
+++ b/thrift/lib/cpp/util/THttpParser.cpp
@@ -18,7 +18,7 @@
 
 #include <thrift/lib/cpp/transport/TTransportException.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Conv.h>
 #include <folly/String.h>
 #include <folly/container/F14Map.h>

--- a/thrift/lib/cpp/util/test/THttpParserTest.cpp
+++ b/thrift/lib/cpp/util/test/THttpParserTest.cpp
@@ -17,7 +17,7 @@
 #include <thrift/lib/cpp/transport/THeader.h>
 #include <thrift/lib/cpp/util/THttpParser.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/thrift/lib/cpp2/FieldRef.cpp
+++ b/thrift/lib/cpp2/FieldRef.cpp
@@ -17,7 +17,7 @@
 #include <thrift/lib/cpp2/BadFieldAccess.h>
 #include <thrift/lib/cpp2/FieldRef.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 [[noreturn]] void apache::thrift::detail::throw_on_bad_optional_field_access() {
   throw bad_optional_field_access();

--- a/thrift/lib/cpp2/GeneratedCodeHelper.h
+++ b/thrift/lib/cpp2/GeneratedCodeHelper.h
@@ -25,7 +25,7 @@
 #include <folly/Memory.h>
 #include <folly/Portability.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Traits.h>
 #include <folly/Utility.h>
 #include <folly/coro/FutureUtil.h>

--- a/thrift/lib/cpp2/async/AsyncProcessorFactory.cpp
+++ b/thrift/lib/cpp2/async/AsyncProcessorFactory.cpp
@@ -16,7 +16,6 @@
 
 #include <thrift/lib/cpp2/async/AsyncProcessorFactory.h>
 
-#include <fmt/core.h>
 #include <fmt/format.h>
 
 namespace apache::thrift {

--- a/thrift/lib/cpp2/async/AsyncProcessorHelper.cpp
+++ b/thrift/lib/cpp2/async/AsyncProcessorHelper.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/lib/cpp2/async/AsyncProcessorHelper.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/lib/cpp/TApplicationException.h>
 
 namespace apache::thrift {

--- a/thrift/lib/cpp2/async/ClientInterceptorBase.cpp
+++ b/thrift/lib/cpp2/async/ClientInterceptorBase.cpp
@@ -18,7 +18,7 @@
 
 #include <folly/lang/SafeAssert.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace apache::thrift {
 

--- a/thrift/lib/cpp2/async/HTTPClientChannel.cpp
+++ b/thrift/lib/cpp2/async/HTTPClientChannel.cpp
@@ -18,7 +18,7 @@
 
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/base64.h>
 #include <proxygen/lib/http/HTTPCommonHeaders.h>
 #include <proxygen/lib/http/HTTPMethod.h>

--- a/thrift/lib/cpp2/async/PooledRequestChannel.cpp
+++ b/thrift/lib/cpp2/async/PooledRequestChannel.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/lib/cpp2/async/PooledRequestChannel.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/logging/xlog.h>
 
 #include <thrift/lib/cpp/transport/TTransportException.h>

--- a/thrift/lib/cpp2/async/RocketClientChannelBase.cpp
+++ b/thrift/lib/cpp2/async/RocketClientChannelBase.cpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ExceptionString.h>
 #include <folly/Memory.h>
 #include <folly/Range.h>

--- a/thrift/lib/cpp2/async/tests/ClientInterceptorTest.cpp
+++ b/thrift/lib/cpp2/async/tests/ClientInterceptorTest.cpp
@@ -23,7 +23,7 @@
 #include <folly/coro/GtestHelpers.h>
 #include <folly/coro/Task.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/lib/cpp/StreamEventHandler.h>
 #include <thrift/lib/cpp2/async/ClientInterceptor.h>

--- a/thrift/lib/cpp2/dynamic/AccumulatingTypeSystem.h
+++ b/thrift/lib/cpp2/dynamic/AccumulatingTypeSystem.h
@@ -23,7 +23,7 @@
 #include <string_view>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/lib/cpp2/dynamic/TypeSystem.h>
 #include <thrift/lib/cpp2/dynamic/TypeSystemDigest.h>

--- a/thrift/lib/cpp2/dynamic/DynamicValue.cpp
+++ b/thrift/lib/cpp2/dynamic/DynamicValue.cpp
@@ -27,7 +27,7 @@
 #include <thrift/lib/cpp2/protocol/DebugProtocol.h>
 #include <thrift/lib/cpp2/protocol/SimpleJSONProtocol.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Overload.h>
 
 #include <iostream>

--- a/thrift/lib/cpp2/dynamic/List.h
+++ b/thrift/lib/cpp2/dynamic/List.h
@@ -25,7 +25,7 @@
 #include <thrift/lib/cpp2/dynamic/detail/ListIteratorBase.h>
 #include <thrift/lib/cpp2/dynamic/fwd.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <stddef.h>
 #include <compare>

--- a/thrift/lib/cpp2/dynamic/Path.h
+++ b/thrift/lib/cpp2/dynamic/Path.h
@@ -20,7 +20,7 @@
 #include <thrift/lib/cpp2/op/Encode.h>
 #include <thrift/lib/cpp2/protocol/SimpleJSONProtocol.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/io/IOBufQueue.h>
 #include <folly/lang/Exception.h>
 

--- a/thrift/lib/cpp2/dynamic/SerializableRecord.cpp
+++ b/thrift/lib/cpp2/dynamic/SerializableRecord.cpp
@@ -25,7 +25,7 @@
 #include <folly/hash/Hash.h>
 #include <folly/lang/Assume.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <ostream>
 

--- a/thrift/lib/cpp2/dynamic/Struct.cpp
+++ b/thrift/lib/cpp2/dynamic/Struct.cpp
@@ -19,7 +19,7 @@
 #include <thrift/lib/cpp2/dynamic/DynamicValue.h>
 #include <thrift/lib/cpp2/dynamic/detail/Datum.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace apache::thrift::dynamic {
 

--- a/thrift/lib/cpp2/dynamic/TypeId.cpp
+++ b/thrift/lib/cpp2/dynamic/TypeId.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/lib/cpp2/dynamic/TypeId.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <ostream>
 

--- a/thrift/lib/cpp2/dynamic/TypeSystem.cpp
+++ b/thrift/lib/cpp2/dynamic/TypeSystem.cpp
@@ -19,7 +19,7 @@
 
 #include <folly/Memory.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <functional>
 #include <memory>

--- a/thrift/lib/cpp2/dynamic/TypeSystem.h
+++ b/thrift/lib/cpp2/dynamic/TypeSystem.h
@@ -33,7 +33,7 @@
 #include <folly/lang/SafeAssert.h>
 #include <folly/memory/not_null.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <memory>
 #include <optional>

--- a/thrift/lib/cpp2/dynamic/Union.cpp
+++ b/thrift/lib/cpp2/dynamic/Union.cpp
@@ -19,7 +19,7 @@
 #include <thrift/lib/cpp2/dynamic/DynamicValue.h>
 #include <thrift/lib/cpp2/dynamic/detail/Datum.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace apache::thrift::dynamic {
 

--- a/thrift/lib/cpp2/dynamic/Union.h
+++ b/thrift/lib/cpp2/dynamic/Union.h
@@ -21,7 +21,7 @@
 #include <thrift/lib/cpp2/dynamic/TypeSystem.h>
 #include <thrift/lib/cpp2/dynamic/fwd.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <memory_resource>
 #include <string_view>

--- a/thrift/lib/cpp2/dynamic/detail/Datum.cpp
+++ b/thrift/lib/cpp2/dynamic/detail/Datum.cpp
@@ -18,7 +18,7 @@
 #include <thrift/lib/cpp2/dynamic/detail/DatumHash.h>
 #include <thrift/lib/cpp2/protocol/DebugProtocol.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace apache::thrift::dynamic::detail {
 

--- a/thrift/lib/cpp2/dynamic/detail/Datum.h
+++ b/thrift/lib/cpp2/dynamic/detail/Datum.h
@@ -31,7 +31,7 @@
 #include <thrift/lib/cpp2/dynamic/Union.h>
 #include <thrift/lib/cpp2/dynamic/fwd.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/CPortability.h>
 #include <folly/Overload.h>
 #include <folly/Traits.h>

--- a/thrift/lib/cpp2/dynamic/detail/TypeSystemImpl.h
+++ b/thrift/lib/cpp2/dynamic/detail/TypeSystemImpl.h
@@ -29,7 +29,7 @@
 #include <folly/container/span.h>
 #include <folly/lang/Assume.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <functional>
 #include <memory>

--- a/thrift/lib/cpp2/fast_thrift/bench/runner/ClientRunner.cpp
+++ b/thrift/lib/cpp2/fast_thrift/bench/runner/ClientRunner.cpp
@@ -20,7 +20,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/logging/xlog.h>
 
 namespace apache::thrift::fast_thrift::bench {

--- a/thrift/lib/cpp2/fast_thrift/bench/runner/ClientRunner.h
+++ b/thrift/lib/cpp2/fast_thrift/bench/runner/ClientRunner.h
@@ -23,7 +23,7 @@
 #include <memory>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/SocketAddress.h>
 #include <folly/coro/Collect.h>
 #include <folly/coro/Task.h>

--- a/thrift/lib/cpp2/fast_thrift/rocket/client/handler/RocketClientRequestResponseHandler.h
+++ b/thrift/lib/cpp2/fast_thrift/rocket/client/handler/RocketClientRequestResponseHandler.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ExceptionWrapper.h>
 #include <folly/io/IOBuf.h>
 #include <folly/lang/Hint.h>

--- a/thrift/lib/cpp2/fast_thrift/rocket/server/handler/RocketServerRequestResponseHandler.h
+++ b/thrift/lib/cpp2/fast_thrift/rocket/server/handler/RocketServerRequestResponseHandler.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ExceptionWrapper.h>
 #include <folly/io/IOBuf.h>
 #include <folly/lang/Hint.h>

--- a/thrift/lib/cpp2/fast_thrift/security/FizzServerContextBuilder.cpp
+++ b/thrift/lib/cpp2/fast_thrift/security/FizzServerContextBuilder.cpp
@@ -20,7 +20,7 @@
 #include <sstream>
 #include <stdexcept>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fizz/backend/openssl/certificate/CertUtils.h>
 #include <fizz/fizz-config.h>
 #include <fizz/protocol/DefaultCertificateVerifier.h>

--- a/thrift/lib/cpp2/fast_thrift/thrift/client/ThriftClientAppAdapter.cpp
+++ b/thrift/lib/cpp2/fast_thrift/thrift/client/ThriftClientAppAdapter.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/lib/cpp2/fast_thrift/thrift/client/ThriftClientAppAdapter.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Expected.h>
 #include <folly/logging/xlog.h>
 #include <thrift/lib/cpp/TApplicationException.h>

--- a/thrift/lib/cpp2/fast_thrift/thrift/client/ThriftClientChannel.cpp
+++ b/thrift/lib/cpp2/fast_thrift/thrift/client/ThriftClientChannel.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/lib/cpp2/fast_thrift/thrift/client/ThriftClientChannel.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/lib/cpp/TApplicationException.h>
 #include <thrift/lib/cpp/transport/THeader.h>
 #include <thrift/lib/cpp/transport/TTransportException.h>

--- a/thrift/lib/cpp2/fast_thrift/thrift/client/util/ErrorDecoding.h
+++ b/thrift/lib/cpp2/fast_thrift/thrift/client/util/ErrorDecoding.h
@@ -25,7 +25,7 @@
 #include <thrift/lib/cpp2/transport/rocket/framing/ErrorCode.h>
 #include <thrift/lib/thrift/gen-cpp2/RpcMetadata_types.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace apache::thrift::fast_thrift::thrift {
 

--- a/thrift/lib/cpp2/fast_thrift/thrift/client/util/RocketFrameDecoder.cpp
+++ b/thrift/lib/cpp2/fast_thrift/thrift/client/util/RocketFrameDecoder.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/lib/cpp2/fast_thrift/thrift/client/util/RocketFrameDecoder.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/lib/cpp/TApplicationException.h>
 #include <thrift/lib/cpp2/fast_thrift/frame/FrameType.h>

--- a/thrift/lib/cpp2/fast_thrift/thrift/server/util/RocketFrameDecoder.cpp
+++ b/thrift/lib/cpp2/fast_thrift/thrift/server/util/RocketFrameDecoder.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/lib/cpp2/fast_thrift/thrift/server/util/RocketFrameDecoder.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/lib/cpp/TApplicationException.h>
 #include <thrift/lib/cpp2/fast_thrift/frame/FrameType.h>

--- a/thrift/lib/cpp2/fast_thrift/transport/TransportHandler.h
+++ b/thrift/lib/cpp2/fast_thrift/transport/TransportHandler.h
@@ -20,7 +20,7 @@
 #include <optional>
 #include <type_traits>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ExceptionWrapper.h>
 #include <folly/Function.h>
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/frozen/test/CompatibilityTest.cpp
+++ b/thrift/lib/cpp2/frozen/test/CompatibilityTest.cpp
@@ -16,7 +16,7 @@
 
 #include <glog/logging.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include <thrift/lib/cpp2/frozen/FrozenUtil.h>

--- a/thrift/lib/cpp2/op/Patch.h
+++ b/thrift/lib/cpp2/op/Patch.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/lib/cpp2/Thrift.h>
 #include <thrift/lib/cpp2/op/Encode.h>
 #include <thrift/lib/cpp2/op/PatchTraits.h>

--- a/thrift/lib/cpp2/protocol/DebugProtocol.h
+++ b/thrift/lib/cpp2/protocol/DebugProtocol.h
@@ -17,7 +17,7 @@
 #ifndef CPP2_PROTOCOL_DEBUGPROTOCOL_H_
 #define CPP2_PROTOCOL_DEBUGPROTOCOL_H_
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/io/Cursor.h>
 #include <folly/io/IOBuf.h>
 #include <folly/portability/GFlags.h>

--- a/thrift/lib/cpp2/protocol/JSONProtocolCommon.cpp
+++ b/thrift/lib/cpp2/protocol/JSONProtocolCommon.cpp
@@ -20,7 +20,6 @@
 #include <type_traits>
 
 #include <iterator>
-#include <fmt/core.h>
 #include <fmt/format.h>
 
 #include <folly/String.h>

--- a/thrift/lib/cpp2/protocol/Patch.cpp
+++ b/thrift/lib/cpp2/protocol/Patch.cpp
@@ -20,7 +20,7 @@
 #include <limits>
 #include <stdexcept>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/MapUtil.h>
 #include <folly/io/IOBufQueue.h>
 #include <folly/lang/Exception.h>

--- a/thrift/lib/cpp2/protocol/detail/Json5ProtocolReader.h
+++ b/thrift/lib/cpp2/protocol/detail/Json5ProtocolReader.h
@@ -73,7 +73,7 @@
 #include <string_view>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Conv.h>
 #include <folly/Exception.h>
 #include <folly/io/Cursor.h>

--- a/thrift/lib/cpp2/protocol/detail/Json5ProtocolWriter.cpp
+++ b/thrift/lib/cpp2/protocol/detail/Json5ProtocolWriter.cpp
@@ -19,7 +19,7 @@
 #include <cmath>
 #include <concepts>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Exception.h>
 #include <folly/Unicode.h>
 #include <folly/base64.h>

--- a/thrift/lib/cpp2/protocol/detail/JsonReader.cpp
+++ b/thrift/lib/cpp2/protocol/detail/JsonReader.cpp
@@ -22,7 +22,7 @@
 #include <limits>
 #include <stdexcept>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Conv.h>
 #include <folly/Unicode.h>
 

--- a/thrift/lib/cpp2/schema/SyntaxGraph.cpp
+++ b/thrift/lib/cpp2/schema/SyntaxGraph.cpp
@@ -24,7 +24,7 @@
 #include <folly/String.h>
 #include <folly/lang/SafeAssert.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <queue>
 #include <stdexcept>

--- a/thrift/lib/cpp2/schema/test/SyntaxGraphTest.cpp
+++ b/thrift/lib/cpp2/schema/test/SyntaxGraphTest.cpp
@@ -32,7 +32,7 @@
 #include <thrift/lib/cpp2/schema/test/gen-cpp2/syntax_graph_handlers.h>
 #include <thrift/lib/cpp2/schema/test/gen-cpp2/syntax_graph_types.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 

--- a/thrift/lib/cpp2/server/CPUConcurrencyController.cpp
+++ b/thrift/lib/cpp2/server/CPUConcurrencyController.cpp
@@ -20,7 +20,7 @@
 
 #include <algorithm>
 #include <chrono>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Overload.h>
 #include <folly/lang/Assume.h>
 

--- a/thrift/lib/cpp2/server/LazyDynamicArguments.cpp
+++ b/thrift/lib/cpp2/server/LazyDynamicArguments.cpp
@@ -18,7 +18,7 @@
 
 #include <glog/logging.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/container/F14Map.h>
 

--- a/thrift/lib/cpp2/server/RequestsRegistry.h
+++ b/thrift/lib/cpp2/server/RequestsRegistry.h
@@ -18,7 +18,7 @@
 
 #include <array>
 #include <chrono>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/IntrusiveList.h>
 #include <folly/SocketAddress.h>
 #include <folly/executors/QueueObserver.h>

--- a/thrift/lib/cpp2/server/ThriftServer.h
+++ b/thrift/lib/cpp2/server/ThriftServer.h
@@ -53,7 +53,7 @@
 #include <folly/observer/Observer.h>
 #include <folly/synchronization/CallOnce.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/lib/cpp/concurrency/PosixThreadFactory.h>
 #include <thrift/lib/cpp/concurrency/Thread.h>

--- a/thrift/lib/cpp2/server/test/ResourcePoolSetTest.cpp
+++ b/thrift/lib/cpp2/server/test/ResourcePoolSetTest.cpp
@@ -19,7 +19,7 @@
 #include <atomic>
 #include <thread>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/synchronization/Latch.h>
 #include <thrift/lib/cpp2/server/ParallelConcurrencyController.h>

--- a/thrift/lib/cpp2/test/CompactProtocolBench.cpp
+++ b/thrift/lib/cpp2/test/CompactProtocolBench.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 #include <folly/Benchmark.h>
 #include <folly/Optional.h>

--- a/thrift/lib/cpp2/test/InstrumentationTest.cpp
+++ b/thrift/lib/cpp2/test/InstrumentationTest.cpp
@@ -22,7 +22,7 @@
 #include <sstream>
 #include <thread>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <folly/ThreadLocal.h>

--- a/thrift/lib/cpp2/test/SerializationTest.cpp
+++ b/thrift/lib/cpp2/test/SerializationTest.cpp
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/lib/cpp2/protocol/Serializer.h>
 #include <thrift/lib/cpp2/test/gen-cpp2/TestService.h>
 

--- a/thrift/lib/cpp2/test/ThriftServerExceptionTest.cpp
+++ b/thrift/lib/cpp2/test/ThriftServerExceptionTest.cpp
@@ -18,7 +18,7 @@
 #include <thrift/lib/cpp2/test/gen-cpp2/Raiser.h>
 #include <thrift/lib/cpp2/util/ScopedServerInterfaceThread.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 #include <folly/coro/BlockingWait.h>
 

--- a/thrift/lib/cpp2/test/e2e/BackpressureE2ETest.cpp
+++ b/thrift/lib/cpp2/test/e2e/BackpressureE2ETest.cpp
@@ -16,7 +16,7 @@
 
 #include <atomic>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/coro/Collect.h>
 #include <folly/coro/GtestHelpers.h>
 #include <folly/coro/Sleep.h>

--- a/thrift/lib/cpp2/test/e2e/BiDiClientCrashE2ETest.cpp
+++ b/thrift/lib/cpp2/test/e2e/BiDiClientCrashE2ETest.cpp
@@ -16,7 +16,7 @@
 
 #include <chrono>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <folly/Subprocess.h>

--- a/thrift/lib/cpp2/test/e2e/BiDiCrashClient.cpp
+++ b/thrift/lib/cpp2/test/e2e/BiDiCrashClient.cpp
@@ -45,7 +45,7 @@
 #include <cstdlib>
 #include <thread>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/coro/BlockingWait.h>
 #include <folly/coro/Collect.h>
 #include <folly/coro/Sleep.h>

--- a/thrift/lib/cpp2/test/e2e/GracefulShutdownE2ETest.cpp
+++ b/thrift/lib/cpp2/test/e2e/GracefulShutdownE2ETest.cpp
@@ -16,7 +16,7 @@
 
 #include <atomic>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/coro/Collect.h>
 #include <folly/coro/GtestHelpers.h>
 #include <folly/coro/Sleep.h>

--- a/thrift/lib/cpp2/test/e2e/StreamCompressionE2ETest.cpp
+++ b/thrift/lib/cpp2/test/e2e/StreamCompressionE2ETest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/base64.h>
 #include <folly/coro/GtestHelpers.h>
 #include <thrift/lib/cpp2/Flags.h>

--- a/thrift/lib/cpp2/test/server/ThriftServerTest.cpp
+++ b/thrift/lib/cpp2/test/server/ThriftServerTest.cpp
@@ -22,7 +22,7 @@
 #include <utility>
 
 #include <boost/cast.hpp>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <common/services/cpp/security/FizzThriftFactory.h>
 #include <gmock/gmock.h>

--- a/thrift/lib/cpp2/test/util/TestHandler.cpp
+++ b/thrift/lib/cpp2/test/util/TestHandler.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/lib/cpp2/test/util/TestHandler.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/io/Cursor.h>
 
 const std::string kEchoSuffix(45, 'c');

--- a/thrift/lib/cpp2/transport/rocket/client/RequestContext.cpp
+++ b/thrift/lib/cpp2/transport/rocket/client/RequestContext.cpp
@@ -20,7 +20,7 @@
 
 #include <glog/logging.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Likely.h>
 #include <folly/io/IOBuf.h>
 #include <folly/lang/Assume.h>

--- a/thrift/lib/cpp2/transport/rocket/client/RocketClient.cpp
+++ b/thrift/lib/cpp2/transport/rocket/client/RocketClient.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Conv.h>
 #include <folly/ExceptionWrapper.h>
 #include <folly/GLog.h>

--- a/thrift/lib/cpp2/transport/rocket/framing/Flags.h
+++ b/thrift/lib/cpp2/transport/rocket/framing/Flags.h
@@ -18,7 +18,7 @@
 
 #include <stdint.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 namespace apache::thrift::rocket {

--- a/thrift/lib/cpp2/transport/rocket/framing/Frames.cpp
+++ b/thrift/lib/cpp2/transport/rocket/framing/Frames.cpp
@@ -22,7 +22,7 @@
 
 #include <glog/logging.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/CPortability.h>
 #include <folly/Likely.h>
 #include <folly/Range.h>

--- a/thrift/lib/cpp2/transport/rocket/framing/parser/AlignedParserStrategy.h
+++ b/thrift/lib/cpp2/transport/rocket/framing/parser/AlignedParserStrategy.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <iostream>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/String.h>
 #include <folly/io/Cursor.h>
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/transport/rocket/server/RefactoredRocketServerConnection.cpp
+++ b/thrift/lib/cpp2/transport/rocket/server/RefactoredRocketServerConnection.cpp
@@ -22,7 +22,7 @@
 // Ensure RocketServerHandler is fully defined before template instantiation
 #include <thrift/lib/cpp2/transport/rocket/server/RocketServerHandler.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ExceptionString.h>
 #include <folly/ExceptionWrapper.h>
 #include <folly/GLog.h>

--- a/thrift/lib/cpp2/transport/rocket/server/RefactoredThriftRocketServerHandler.cpp
+++ b/thrift/lib/cpp2/transport/rocket/server/RefactoredThriftRocketServerHandler.cpp
@@ -22,7 +22,7 @@
 #include <folly/ExceptionWrapper.h>
 #include <folly/stop_watch.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ExceptionString.h>
 #include <thrift/lib/cpp2/Flags.h>
 #include <thrift/lib/cpp2/server/Cpp2ConnContext.h>

--- a/thrift/lib/cpp2/transport/rocket/server/RocketBiDiClientCallback.cpp
+++ b/thrift/lib/cpp2/transport/rocket/server/RocketBiDiClientCallback.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/lib/cpp2/transport/rocket/server/RocketBiDiClientCallback.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/lib/cpp/TApplicationException.h>
 #include <thrift/lib/cpp2/transport/rocket/RocketException.h>

--- a/thrift/lib/cpp2/transport/rocket/server/RocketServerConnection.cpp
+++ b/thrift/lib/cpp2/transport/rocket/server/RocketServerConnection.cpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ExceptionString.h>
 #include <folly/ExceptionWrapper.h>
 #include <folly/GLog.h>

--- a/thrift/lib/cpp2/transport/rocket/server/RocketSinkClientCallback.cpp
+++ b/thrift/lib/cpp2/transport/rocket/server/RocketSinkClientCallback.cpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 #include <folly/ExceptionWrapper.h>

--- a/thrift/lib/cpp2/transport/rocket/server/RocketStreamClientCallback.cpp
+++ b/thrift/lib/cpp2/transport/rocket/server/RocketStreamClientCallback.cpp
@@ -16,7 +16,7 @@
 
 #include <thrift/lib/cpp2/transport/rocket/server/RocketStreamClientCallback.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <thrift/lib/cpp2/transport/rocket/server/RocketServerUtil.h>
 #include <thrift/lib/thrift/gen-cpp2/RpcMetadata_types.h>

--- a/thrift/lib/cpp2/transport/rocket/server/ThriftRocketServerHandler.cpp
+++ b/thrift/lib/cpp2/transport/rocket/server/ThriftRocketServerHandler.cpp
@@ -19,7 +19,7 @@
 #include <memory>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ExceptionString.h>
 #include <folly/ExceptionWrapper.h>
 #include <folly/GLog.h>

--- a/thrift/lib/cpp2/transport/rocket/server/detail/ExistingStreamFrameHandler.h
+++ b/thrift/lib/cpp2/transport/rocket/server/detail/ExistingStreamFrameHandler.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Likely.h>
 #include <folly/Overload.h>
 #include <folly/io/Cursor.h>

--- a/thrift/lib/cpp2/transport/rocket/server/detail/IncomingFrameHandler.h
+++ b/thrift/lib/cpp2/transport/rocket/server/detail/IncomingFrameHandler.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Overload.h>
 #include <folly/String.h>
 #include <folly/io/Cursor.h>

--- a/thrift/lib/cpp2/transport/rocket/server/detail/RocketRequestOrchestrator.h
+++ b/thrift/lib/cpp2/transport/rocket/server/detail/RocketRequestOrchestrator.h
@@ -19,7 +19,7 @@
 #include <chrono>
 #include <memory>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/io/async/AsyncTransport.h>
 #include <folly/synchronization/CallOnce.h>

--- a/thrift/lib/cpp2/transport/rocket/server/detail/RocketSetupProcessor.cpp
+++ b/thrift/lib/cpp2/transport/rocket/server/detail/RocketSetupProcessor.cpp
@@ -19,7 +19,7 @@
 #include <algorithm>
 #include <cstdint>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 #include <folly/ExceptionString.h>
 #include <folly/ExceptionWrapper.h>

--- a/thrift/lib/cpp2/transport/rocket/test/network/RocketNetworkTest.cpp
+++ b/thrift/lib/cpp2/transport/rocket/test/network/RocketNetworkTest.cpp
@@ -23,7 +23,7 @@
 
 #include <gtest/gtest.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Conv.h>
 #include <folly/ExceptionWrapper.h>
 #include <folly/Range.h>

--- a/thrift/lib/cpp2/type/AlignedPtr.h
+++ b/thrift/lib/cpp2/type/AlignedPtr.h
@@ -18,7 +18,7 @@
 
 #include <stdexcept>
 #include <type_traits>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/ConstexprMath.h>
 #include <folly/lang/Bits.h>
 #include <folly/lang/Exception.h>

--- a/thrift/lib/cpp2/type/Id.h
+++ b/thrift/lib/cpp2/type/Id.h
@@ -27,7 +27,7 @@
 #include <stdexcept>
 #include <type_traits>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Traits.h>
 #include <folly/Utility.h>
 #include <folly/lang/Exception.h>

--- a/thrift/lib/cpp2/type/UniversalName.cpp
+++ b/thrift/lib/cpp2/type/UniversalName.cpp
@@ -21,7 +21,7 @@
 
 #include <openssl/evp.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Range.h>
 #include <folly/lang/Exception.h>
 #include <folly/portability/OpenSSL.h>

--- a/thrift/lib/cpp2/type/UniversalNameTest.cpp
+++ b/thrift/lib/cpp2/type/UniversalNameTest.cpp
@@ -20,7 +20,7 @@
 
 #include <openssl/evp.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 #include <folly/Demangle.h>
 #include <folly/FBString.h>

--- a/thrift/lib/cpp2/type/detail/Name.h
+++ b/thrift/lib/cpp2/type/detail/Name.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/lang/Pretty.h>
 #include <thrift/lib/cpp2/Thrift.h>
 #include <thrift/lib/cpp2/type/NativeType.h>

--- a/thrift/lib/cpp2/util/DebugString.cpp
+++ b/thrift/lib/cpp2/util/DebugString.cpp
@@ -17,7 +17,7 @@
 #include <thrift/lib/cpp2/util/DebugString.h>
 
 #include <unordered_map>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/MapUtil.h>
 #include <folly/String.h>
 #include <thrift/lib/cpp2/protocol/BinaryProtocol.h>

--- a/thrift/lib/thrift/detail/TypeIdAdapter.cpp
+++ b/thrift/lib/thrift/detail/TypeIdAdapter.cpp
@@ -18,7 +18,7 @@
 
 #include <thrift/lib/thrift/gen-cpp2/type_id_types.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace apache::thrift::type_system::detail {
 

--- a/thrift/lib/thrift/detail/TypeIdAdapter.h
+++ b/thrift/lib/thrift/detail/TypeIdAdapter.h
@@ -25,7 +25,7 @@
 #include <folly/lang/Assume.h>
 #include <folly/lang/Exception.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <stdexcept>
 #include <string>

--- a/thrift/lib/thrift/detail/TypeSystemAdapter.cpp
+++ b/thrift/lib/thrift/detail/TypeSystemAdapter.cpp
@@ -20,7 +20,7 @@
 
 #include <folly/hash/Hash.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 using apache::thrift::type_system::FieldId;
 using apache::thrift::type_system::FieldIdentity;

--- a/thrift/lib/thrift/detail/TypeSystemAdapter.h
+++ b/thrift/lib/thrift/detail/TypeSystemAdapter.h
@@ -23,7 +23,7 @@
 
 #include <folly/lang/Exception.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <string_view>
 #include <type_traits>

--- a/thrift/test/python_capi/adapter.h
+++ b/thrift/test/python_capi/adapter.h
@@ -18,7 +18,7 @@
 
 #include <string>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <thrift/lib/cpp2/op/Get.h>
 
 namespace thrift::test::lib {


### PR DESCRIPTION
## Problem

fmtlib/fmt deprecated `<fmt/core.h>` in commit [0007426](https://github.com/fmtlib/fmt/commit/0007426c2d8d22df6e56d3b4d109415242e683e0). Starting from fmt 12.2.0, using `<fmt/core.h>` causes compilation errors because the deprecated include is now opt-in only.

## Fix

Replace all `#include <fmt/core.h>` with `#include <fmt/format.h>`, which is the standard header in fmt 12.2.0+.