### PR TITLE
Add missing <cstring> includes for std::mem*/std::str*

### DIFF
--- a/thrift/compiler/generate/t_concat_generator.cc
+++ b/thrift/compiler/generate/t_concat_generator.cc
@@ -18,6 +18,7 @@
 
 #include <cinttypes>
 #include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <iterator>
 

--- a/thrift/conformance/stresstest/server/StressTestHandler.cpp
+++ b/thrift/conformance/stresstest/server/StressTestHandler.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cstring>
+
 #include <common/services/cpp/security/SecureThriftUtil.h>
 #include <thrift/conformance/stresstest/server/StressTestHandler.h>
 

--- a/thrift/lib/cpp/util/test/THttpParserTest.cpp
+++ b/thrift/lib/cpp/util/test/THttpParserTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cstring>
+
 #include <thrift/lib/cpp/transport/THeader.h>
 #include <thrift/lib/cpp/util/THttpParser.h>
 

--- a/thrift/lib/cpp2/fast_thrift/frame/bench/FrameWritingBench.cpp
+++ b/thrift/lib/cpp2/fast_thrift/frame/bench/FrameWritingBench.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cstring>
+
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/frame/read/handler/bench/FrameLengthParserHandlerBench.cpp
+++ b/thrift/lib/cpp2/fast_thrift/frame/read/handler/bench/FrameLengthParserHandlerBench.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cstring>
+
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/frame/read/handler/test/FrameLengthParserHandlerTest.cpp
+++ b/thrift/lib/cpp2/fast_thrift/frame/read/handler/test/FrameLengthParserHandlerTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cstring>
+
 #include <gtest/gtest.h>
 
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/frame/write/handler/test/FrameFragmentationHandlerTest.cpp
+++ b/thrift/lib/cpp2/fast_thrift/frame/write/handler/test/FrameFragmentationHandlerTest.cpp
@@ -23,6 +23,7 @@
 #include <folly/io/IOBuf.h>
 #include <folly/io/async/EventBase.h>
 
+#include <cstring>
 #include <map>
 #include <stdexcept>
 #include <vector>

--- a/thrift/lib/cpp2/fast_thrift/frame/write/handler/test/FrameLengthEncoderHandlerTest.cpp
+++ b/thrift/lib/cpp2/fast_thrift/frame/write/handler/test/FrameLengthEncoderHandlerTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cstring>
+
 #include <gtest/gtest.h>
 
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/rocket/bench/BenchContext.h
+++ b/thrift/lib/cpp2/fast_thrift/rocket/bench/BenchContext.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstring>
+
 #include <folly/ExceptionWrapper.h>
 #include <folly/io/IOBuf.h>
 #include <thrift/lib/cpp2/fast_thrift/channel_pipeline/BufferAllocator.h>

--- a/thrift/lib/cpp2/fast_thrift/rocket/client/handler/test/RocketClientConnectionErrorHandlerTest.cpp
+++ b/thrift/lib/cpp2/fast_thrift/rocket/client/handler/test/RocketClientConnectionErrorHandlerTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cstring>
+
 #include <gtest/gtest.h>
 
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/rocket/client/handler/test/RocketClientStreamStateHandlerTest.cpp
+++ b/thrift/lib/cpp2/fast_thrift/rocket/client/handler/test/RocketClientStreamStateHandlerTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstring>
 
 #include <folly/io/IOBuf.h>
 #include <thrift/lib/cpp/transport/TTransportException.h>

--- a/thrift/lib/cpp2/fast_thrift/rocket/client/test/RocketClientIntegrationTest.cpp
+++ b/thrift/lib/cpp2/fast_thrift/rocket/client/test/RocketClientIntegrationTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstring>
 
 #include <folly/io/Cursor.h>
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/rocket/server/handler/bench/RocketServerRequestResponseHandlerBench.cpp
+++ b/thrift/lib/cpp2/fast_thrift/rocket/server/handler/bench/RocketServerRequestResponseHandlerBench.cpp
@@ -25,6 +25,8 @@
  *   - Write:       PAYLOAD on RR stream — stamp complete=true, next=true.
  */
 
+#include <cstring>
+
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/rocket/server/handler/bench/RocketServerSetupFrameHandlerBench.cpp
+++ b/thrift/lib/cpp2/fast_thrift/rocket/server/handler/bench/RocketServerSetupFrameHandlerBench.cpp
@@ -23,6 +23,8 @@
  * - Outbound: Write passthrough
  */
 
+#include <cstring>
+
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/rocket/server/handler/bench/RocketServerStreamStateHandlerBench.cpp
+++ b/thrift/lib/cpp2/fast_thrift/rocket/server/handler/bench/RocketServerStreamStateHandlerBench.cpp
@@ -26,6 +26,8 @@
  * - Inbound: New stream registration under map pressure (many active streams)
  */
 
+#include <cstring>
+
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/rocket/server/handler/test/RocketServerSetupFrameHandlerTest.cpp
+++ b/thrift/lib/cpp2/fast_thrift/rocket/server/handler/test/RocketServerSetupFrameHandlerTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cstring>
+
 #include <gtest/gtest.h>
 
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/rocket/server/handler/test/RocketServerStreamStateHandlerTest.cpp
+++ b/thrift/lib/cpp2/fast_thrift/rocket/server/handler/test/RocketServerStreamStateHandlerTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cstring>
+
 #include <gtest/gtest.h>
 
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/rocket/server/test/RocketServerIntegrationTest.cpp
+++ b/thrift/lib/cpp2/fast_thrift/rocket/server/test/RocketServerIntegrationTest.cpp
@@ -36,6 +36,8 @@
  * pointer in TransportHandler.
  */
 
+#include <cstring>
+
 #include <gtest/gtest.h>
 
 #include <folly/io/Cursor.h>

--- a/thrift/lib/cpp2/fast_thrift/thrift/client/handler/bench/ThriftClientChecksumHandlerBench.cpp
+++ b/thrift/lib/cpp2/fast_thrift/thrift/client/handler/bench/ThriftClientChecksumHandlerBench.cpp
@@ -28,6 +28,8 @@
  *      is the only supported algorithm; CRC32 / SERVER_ONLY_CRC32 are not.
  */
 
+#include <cstring>
+
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/thrift/server/bench/HeadroomPipelineBench.cpp
+++ b/thrift/lib/cpp2/fast_thrift/thrift/server/bench/HeadroomPipelineBench.cpp
@@ -28,6 +28,8 @@
  *   (writes header into headroom, zero alloc)
  */
 
+#include <cstring>
+
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/thrift/server/bench/RequestDeserializationBench.cpp
+++ b/thrift/lib/cpp2/fast_thrift/thrift/server/bench/RequestDeserializationBench.cpp
@@ -30,6 +30,8 @@
  * isolates the cost of the heap allocation and indirection.
  */
 
+#include <cstring>
+
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/thrift/server/test/ThriftServerChannelTest.cpp
+++ b/thrift/lib/cpp2/fast_thrift/thrift/server/test/ThriftServerChannelTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cstring>
+
 #include <gtest/gtest.h>
 
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/fast_thrift/transport/test/TestAsyncTransport.h
+++ b/thrift/lib/cpp2/fast_thrift/transport/test/TestAsyncTransport.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstring>
+
 #include <folly/io/IOBuf.h>
 #include <folly/io/IOBufQueue.h>
 #include <folly/io/async/AsyncTransport.h>

--- a/thrift/lib/cpp2/fast_thrift/transport/test/TransportHandlerTest.cpp
+++ b/thrift/lib/cpp2/fast_thrift/transport/test/TransportHandlerTest.cpp
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
 #include <memory>
 
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/cpp2/protocol/NativeObject.h
+++ b/thrift/lib/cpp2/protocol/NativeObject.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <string>
 #include <variant>

--- a/thrift/lib/cpp2/protocol/test/CompactV1ProtocolTest.cpp
+++ b/thrift/lib/cpp2/protocol/test/CompactV1ProtocolTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cstring>
+
 #include <gtest/gtest.h>
 
 #include <thrift/lib/cpp2/protocol/CompactV1Protocol.h>

--- a/thrift/lib/cpp2/transport/rocket/framing/Serializer.h
+++ b/thrift/lib/cpp2/transport/rocket/framing/Serializer.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstring>
 #include <memory>
 #include <type_traits>
 

--- a/thrift/lib/cpp2/transport/rocket/framing/parser/test/AlignedParserStrategySecurityTest.cpp
+++ b/thrift/lib/cpp2/transport/rocket/framing/parser/test/AlignedParserStrategySecurityTest.cpp
@@ -23,6 +23,8 @@
 // rejects undersized frames and oversized metadata claims without underflow.
 //
 
+#include <cstring>
+
 #include <gtest/gtest.h>
 #include <folly/io/IOBuf.h>
 #include <thrift/lib/cpp2/transport/rocket/framing/Frames.h>

--- a/thrift/lib/cpp2/transport/rocket/framing/parser/test/AlignedParserStrategyTest.cpp
+++ b/thrift/lib/cpp2/transport/rocket/framing/parser/test/AlignedParserStrategyTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cstring>
+
 #include <gtest/gtest.h>
 #include <folly/String.h>
 #include <folly/io/IOBuf.h>

--- a/thrift/lib/py3/test/BinaryTypes.h
+++ b/thrift/lib/py3/test/BinaryTypes.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstring>
 #include <string>
 
 #include <boost/operators.hpp>


### PR DESCRIPTION
Add missing <cstring> includes for std::mem*/std::str*

These files call std::memcpy/std::memset/std::strlen etc. but rely on
<cstring> being pulled in transitively via other standard headers. Newer
libstdc++ (GCC 13) no longer provides it that way, so they fail to compile:

    error: 'memcpy' is not a member of 'std'; did you mean 'wmemcpy'?

Include <cstring> directly in each affected translation unit
(include-what-you-use).