### PR TITLE
Fix duplicated-word and misspelling typos in comments and docs

### DIFF
--- a/thrift/annotation/rust.thrift
+++ b/thrift/annotation/rust.thrift
@@ -169,7 +169,7 @@ struct NewType {}
  *
  * "Codegen" errors or bugs resulting from the use of standard types in valid
  * positions in `@rust.Type` annotations should be considered the responsibility
- * of the the Rust Thrift maintainers to address. Less "formal" support should
+ * of the Rust Thrift maintainers to address. Less "formal" support should
  * be expected from the Rust Thrift maintainers when nonstandard types are
  * involved.
  *

--- a/thrift/annotation/thrift.thrift
+++ b/thrift/annotation/thrift.thrift
@@ -239,7 +239,7 @@ enum RpcPriority {
  * In practice, this means that this type is safe to use as a map key type or as
  * a set element type, but any change to its schema (including changes that are
  * "typically" considered safe, such as adding a new field) MAY break backwards
- * compatiblity.
+ * compatibility.
  *
  * Note that the tooling and environment in which Thrift IDL definitions live
  * (such as code repositories) may not be explicitly preventing such changes:

--- a/thrift/compiler/ast/t_type.h
+++ b/thrift/compiler/ast/t_type.h
@@ -337,7 +337,7 @@ class t_type_ref final {
    * resolution will be attempted from).
    * `nullptr` if this type ref is empty, or already resolved.
    * E.g. if a node in the program `foo` references a currently unresolved type
-   * `bar.Baz`, this will be a a pointer to the program `foo` (NOT `bar`).
+   * `bar.Baz`, this will be a pointer to the program `foo` (NOT `bar`).
    */
   const t_program* unresolved_program_ = nullptr;
   std::string unresolved_name_;

--- a/thrift/compiler/sema/schematizer.h
+++ b/thrift/compiler/sema/schematizer.h
@@ -34,7 +34,7 @@ class schematizer {
   enum class value_id : int64_t {};
 
   struct options {
-    bool double_writes : 1; // Legacy copies of data for backward compatiblity.
+    bool double_writes : 1; // Legacy copies of data for backward compatibility.
 
     bool include_annotations : 1;
     bool include_docs : 1;

--- a/thrift/compiler/source_location.cc
+++ b/thrift/compiler/source_location.cc
@@ -295,7 +295,7 @@ source_manager::path_or_error source_manager::find_include_file(
     return source_manager::path_or_error{std::in_place_index<0>, itr->second};
   }
 
-  // Convenience callback to use when the path the the include has been
+  // Convenience callback to use when the path the include has been
   // succcessfully resolved: updates the set of known paths and returns a
   // successful resutl with the resolved path.
   auto new_found_include = [&](std::string path) {

--- a/thrift/compiler/whisker/print_ast.cc
+++ b/thrift/compiler/whisker/print_ast.cc
@@ -46,7 +46,7 @@ std::string to_string(
   resolved_location end = src_manager.resolve_location(loc.end);
   // Format of a source location is:
   //   line:<line>:<column>
-  // If begin and end are on the same line, the the end source location is:
+  // If begin and end are on the same line, the end source location is:
   //   col:<column>
   return fmt::format(
       "<line:{}:{}, {}>",

--- a/thrift/doc/contributions/whisker.md
+++ b/thrift/doc/contributions/whisker.md
@@ -1493,7 +1493,7 @@ Use [`{{#let}}`](#let-statements), [`{{#import}}](#import-statements), `as` capt
 
 ### Derived Evaluation Context
 
-Whisker renders `{{#let partial}}` blocks within a new evaluation context *derived* from the the call site. This context starts with an empty stack but retains access to the same global scope.
+Whisker renders `{{#let partial}}` blocks within a new evaluation context *derived* from the call site. This context starts with an empty stack but retains access to the same global scope.
 
 ## Standalone Tags
 

--- a/thrift/doc/features/any.md
+++ b/thrift/doc/features/any.md
@@ -58,7 +58,7 @@ The `type` field within the `AnyStruct` provides the `name` of the type and any 
 The Type Registry is a crucial component in the deserialization process of user-defined types stored in `AnyStruct`. It maintains a mapping from the universal name (stored in the `type` field) to its native generated type. This mapping allows the deserialization process to correctly interpret the data stored in AnyStruct and convert it back into its original user-defined type. The Thrift generated structs, which have a universal name provided, are registered in the TypeRegistry as part of the initialization code.
 
 :::note
-Type Registry is available in C++, Hack, Python and Java. In C++, you need to add a compiler option `any` in order to generate intialization code to register Thrift types.
+Type Registry is available in C++, Hack, Python and Java. In C++, you need to add a compiler option `any` in order to generate initialization code to register Thrift types.
 :::
 
 ### Protocol

--- a/thrift/doc/glossary/kinds-of-types.md
+++ b/thrift/doc/glossary/kinds-of-types.md
@@ -74,7 +74,7 @@ possible native types can therefore be categorized as shown below.:
 
 #### Default Target Types
 
-Default target types are are the ones used by default by the Thrift compiler for
+Default target types are the ones used by default by the Thrift compiler for
 the corresponding target generated language. They are obviously supported by
 Thrift, and are the ones used unless the user explicitly specifies otherwise
 (typically, through annotations).

--- a/thrift/lib/cpp/Frozen.h
+++ b/thrift/lib/cpp/Frozen.h
@@ -42,7 +42,7 @@
  * be written to disk, mmap'ed back, and used in-place without any
  * deserialization.
  *
- * These types require that the the structure does not change between freeze and
+ * These types require that the structure does not change between freeze and
  * thaw. Any versioning mismatches will lead to undefined behavior.
  *
  * To enable the necessary code generation for these types, enable the 'frozen'

--- a/thrift/lib/cpp/concurrency/PosixThreadFactory.cpp
+++ b/thrift/lib/cpp/concurrency/PosixThreadFactory.cpp
@@ -63,7 +63,7 @@ PthreadThread::PthreadThread(
 }
 
 PthreadThread::~PthreadThread() {
-  /* Nothing references this thread, if is is not detached, do a join
+  /* Nothing references this thread, if it is not detached, do a join
      now, otherwise the thread-id and, possibly, other resources will
      be leaked. */
   if (!detached_) {

--- a/thrift/lib/cpp/test/loadgen/RNG.h
+++ b/thrift/lib/cpp/test/loadgen/RNG.h
@@ -61,7 +61,7 @@ class RNG {
    * This value is used to pick seeds for new thread-local RNGs.
    * It won't affect thread-local RNGs that have already been created.
    *
-   * Note that that the seed value used for each thread-local RNG depends on
+   * Note that the seed value used for each thread-local RNG depends on
    * the order in which the thread-local RNGs are created.  You may not get
    * consistent results across runs if your threads are not initialized in a
    * consistent order.

--- a/thrift/lib/cpp/transport/THttpClient.cpp
+++ b/thrift/lib/cpp/transport/THttpClient.cpp
@@ -108,7 +108,7 @@ bool THttpClient::parseStatusLine(char* status) {
   // code. Skip over it.
   ++code;
 
-  // RFC 2616 requires exactly 1 space between the the status code and reason
+  // RFC 2616 requires exactly 1 space between the status code and reason
   // phrase.
   const char* endCode = strchr(code, ' ');
   if (endCode == nullptr) {

--- a/thrift/lib/cpp/util/VarintUtils-inl.h
+++ b/thrift/lib/cpp/util/VarintUtils-inl.h
@@ -346,7 +346,7 @@ inline size_t readContiguousVarintMediumSlowU64BMI2(
   size_t intBytes = (maskShift >> 3) + 1;
 
   uint64_t mask = (1ULL << maskShift) - 1;
-  // You might think it would make more sense to to the pext first and mask
+  // You might think it would make more sense to do the pext first and mask
   // afterwards (avoiding having two pexts in a single dependency chain at 3
   // cycles / pop); this seems not to be borne out in microbenchmarks. The
   // mask you need ends up being more complicated to compute.

--- a/thrift/lib/cpp2/frozen/Frozen.h
+++ b/thrift/lib/cpp2/frozen/Frozen.h
@@ -223,7 +223,7 @@ struct LayoutBase {
   explicit LayoutBase(std::type_index _type) : type(std::move(_type)) {}
 
   /**
-   * Internal: Updates the size of this structure according the the result of a
+   * Internal: Updates the size of this structure according to the result of a
    * layout attempt. Returns true iff another pass of layout will be needed.
    */
   bool resize(FieldPosition after, bool inlined);

--- a/thrift/lib/cpp2/frozen/FrozenUtil.h
+++ b/thrift/lib/cpp2/frozen/FrozenUtil.h
@@ -105,7 +105,7 @@ size_t frozenSize(const T& v) {
 
 /**
  * Returns an upper bound estimate of the number of bytes required to freeze
- * this object with a given layout. Actual bytes required will depend on on
+ * this object with a given layout. Actual bytes required will depend on
  * the alignment of the freeze buffer.
  */
 template <class T>

--- a/thrift/lib/cpp2/op/Get.h
+++ b/thrift/lib/cpp2/op/Get.h
@@ -330,7 +330,7 @@ FOLLY_ALWAYS_INLINE constexpr void for_each_ordinal(F&& f) {
       std::forward<F>(f), std::make_integer_sequence<size_t, num_fields<T>>{});
 }
 
-/// Calls the given function with with ordinal<1> to ordinal<N>, returing the
+/// Calls the given function with ordinal<1> to ordinal<N>, returning the
 /// first 'true' result produced.
 template <
     typename T,
@@ -391,7 +391,7 @@ FOLLY_ALWAYS_INLINE constexpr void for_each_field_id_ascending(F&& f) {
       std::forward<F>(f), std::make_integer_sequence<size_t, num_fields<T>>{});
 }
 
-/// Calls the given function with with each field_id<{id}>, returning the
+/// Calls the given function with each field_id<{id}>, returning the
 /// first 'true' result produced.
 template <typename T, typename F>
 decltype(auto) find_by_field_id(F&& f) {

--- a/thrift/lib/cpp2/protocol/detail/FieldMaskUtil.cpp
+++ b/thrift/lib/cpp2/protocol/detail/FieldMaskUtil.cpp
@@ -24,7 +24,7 @@ void ensure_fields(MaskRef ref, type::AnyStruct& t) {
         "Cannot ensure Any field (schemaless ensure is unsafe)");
   }
 
-  // backwards compatiblity with field mask
+  // backwards compatibility with field mask
   return ensure_fields<type::AnyStruct>(ref, t);
 }
 

--- a/thrift/lib/cpp2/server/DecoratorData.h
+++ b/thrift/lib/cpp2/server/DecoratorData.h
@@ -25,7 +25,7 @@ namespace apache::thrift::server {
 
 /**
  * This is the interface that Service Interceptor, Service handlers, and
- * decorators will have access to to read and write from decorator data. put()
+ * decorators will have access to read and write from decorator data. put()
  * is only usable from a non-const interface, whereas get() is usable from
  * both const and non-const interfaces.
  */

--- a/thrift/lib/cpp2/server/ParallelConcurrencyController.h
+++ b/thrift/lib/cpp2/server/ParallelConcurrencyController.h
@@ -129,7 +129,7 @@ class ParallelConcurrencyController : public ParallelConcurrencyControllerBase {
   /**
    *
    * @param requestExecutor: If set to RequestExecutor::Serial, the requests
-   * will be executed using a a folly::SerialExecutor. Consider using this if
+   * will be executed using a folly::SerialExecutor. Consider using this if
    * your code uses coroutines.
    */
   ParallelConcurrencyController(

--- a/thrift/lib/cpp2/server/ResourcePoolSet.h
+++ b/thrift/lib/cpp2/server/ResourcePoolSet.h
@@ -111,7 +111,7 @@ class ResourcePoolSet {
   // frequently.
   std::size_t workerCount() const;
 
-  // Returns the number of of idle threads in this ResourcePoolSet.
+  // Returns the number of idle threads in this ResourcePoolSet.
   // This is inteded for reporting statistics and should not be called
   // frequently.
   std::size_t idleWorkerCount() const;

--- a/thrift/lib/cpp2/server/ServiceInterceptorBase.h
+++ b/thrift/lib/cpp2/server/ServiceInterceptorBase.h
@@ -340,7 +340,7 @@ class ServiceInterceptorBase {
 
   /**
    * This methods is called by ThriftServer to set the module name for the
-   * interceptor. This method is expected to be called prior to to the
+   * interceptor. This method is expected to be called prior to the
    * the interceptor methods being executed on any request, as it performs
    * various secondary intitialization requiring module name to be known.
    */

--- a/thrift/lib/cpp2/server/ServiceInterceptorQualifiedName.h
+++ b/thrift/lib/cpp2/server/ServiceInterceptorQualifiedName.h
@@ -23,7 +23,7 @@ namespace apache::thrift {
 
 /**
  * Service Interceptors are uniquely identified by
- * {moduleName}.{interceptorName} at runtime. Module Name is the the name of
+ * {moduleName}.{interceptorName} at runtime. Module Name is the name of
  * module that installed the interceptor, and Interceptor Name is the result
  * of calling the getName() method on the interceptor.
  */

--- a/thrift/lib/cpp2/server/ThriftServer.h
+++ b/thrift/lib/cpp2/server/ThriftServer.h
@@ -3358,7 +3358,7 @@ class ThriftServer : public apache::thrift::concurrency::Runnable,
    * then we schedule a task to dump the server's state to disk for
    * investigation.
    *
-   * The implementor of the dumping logic should provide the the task as well
+   * The implementor of the dumping logic should provide the task as well
    * as an appropriate timeout -- we do not want to indefinitely block shutdown
    * in case the task deadlocks.
    */

--- a/thrift/lib/cpp2/test/FrozenTest.cpp
+++ b/thrift/lib/cpp2/test/FrozenTest.cpp
@@ -80,7 +80,7 @@ TEST(Frozen, Basic) {
     auto* freezeResult = freeze(team, buffer);
     const byte* const frozenLocation =
         static_cast<const byte*>(static_cast<const void*>(freezeResult));
-    // verify that freeze didn't yeild a different address.
+    // verify that freeze didn't yield a different address.
     EXPECT_EQ(freezeLocation - &bytes[0], frozenLocation - &bytes[0]);
 
     std::vector<byte> copy(bytes);

--- a/thrift/lib/cpp2/test/ThriftObjectProfile.cpp
+++ b/thrift/lib/cpp2/test/ThriftObjectProfile.cpp
@@ -56,7 +56,7 @@ DEFINE_string(type, "", "The type to profile.");
 DEFINE_string(
     protocol,
     "Binary",
-    "The protocol used to to serialize/deserialize Protocol.Object/Value with");
+    "The protocol used to serialize/deserialize Protocol.Object/Value with");
 DEFINE_string(impl, "protocol", "The implementation for Object");
 
 template <

--- a/thrift/lib/cpp2/test/frozen1/FrozenTest.cpp
+++ b/thrift/lib/cpp2/test/frozen1/FrozenTest.cpp
@@ -80,7 +80,7 @@ TEST(Frozen, Basic) {
     auto* freezeResult = freeze(team, buffer);
     const byte* const frozenLocation =
         static_cast<const byte*>(static_cast<const void*>(freezeResult));
-    // verify that freeze didn't yeild a different address.
+    // verify that freeze didn't yield a different address.
     EXPECT_EQ(freezeLocation - &bytes[0], frozenLocation - &bytes[0]);
 
     std::vector<byte> copy(bytes);

--- a/thrift/lib/cpp2/transport/rocket/client/RequestContext.h
+++ b/thrift/lib/cpp2/transport/rocket/client/RequestContext.h
@@ -55,7 +55,7 @@ class RequestContext {
   };
 
   enum class State : uint8_t {
-    DEFERRED_INIT, /* still needs to be intialized with server version */
+    DEFERRED_INIT, /* still needs to be initialized with server version */
     WRITE_NOT_SCHEDULED,
     WRITE_SCHEDULED,
     WRITE_SENDING, /* AsyncSocket::writeChain() called, but WriteCallback has

--- a/thrift/lib/cpp2/transport/rocket/compression/CompressionAlgorithmSelector.cpp
+++ b/thrift/lib/cpp2/transport/rocket/compression/CompressionAlgorithmSelector.cpp
@@ -188,7 +188,7 @@ CompressionAlgorithmSelector::toCodecTypeAndLevel(
       // implementation details, folly segmented these negative ZSTD levels into
       // a "ZSTD_FAST" codec type where positive levels are translated to
       // negative levels for the underlying base codec. This magic "7" (-7 for
-      // the underlying base codec) was determined to to be sane by an internal
+      // the underlying base codec) was determined to be sane by an internal
       // customer.
       return {
           folly::compression::CodecType::ZSTD_FAST,

--- a/thrift/lib/cpp2/transport/rocket/server/RefactoredRocketServerConnection.cpp
+++ b/thrift/lib/cpp2/transport/rocket/server/RefactoredRocketServerConnection.cpp
@@ -138,7 +138,7 @@ RefactoredRocketServerConnection::RefactoredRocketServerConnection(
     }
   }
 
-  // To prevent a C++ intialization error we need to initialize the the observer
+  // To prevent a C++ initialization error we need to initialize the observer
   // container after the vtable is fully created
   this->initializeObserverContainer();
 }

--- a/thrift/lib/cpp2/transport/rocket/server/RocketServerConnection.cpp
+++ b/thrift/lib/cpp2/transport/rocket/server/RocketServerConnection.cpp
@@ -144,7 +144,7 @@ RocketServerConnection::RocketServerConnection(
     }
   }
 
-  // To prevent a C++ intialization error we need to initialize the the observer
+  // To prevent a C++ initialization error we need to initialize the observer
   // container after the vtable is fully created
   this->initializeObserverContainer();
 }

--- a/thrift/lib/cpp2/transport/rocket/server/detail/OutgoingFrameHandler.h
+++ b/thrift/lib/cpp2/transport/rocket/server/detail/OutgoingFrameHandler.h
@@ -94,7 +94,7 @@ struct WriteBatch {
 
 /**
  * OutgoingFrameHandler receives Frames in batches in the handle method. It then
- * schedules a a job on the event loop to process the frames up to the batch
+ * schedules a job on the event loop to process the frames up to the batch
  * size. If it hits the current batch size it'll process them immediately rather
  * than waiting, and rescheduling if there's frames left. This class is meant to
  * only run on the event base threads and is *NOT* thread-safe. It's shared

--- a/thrift/lib/java/runtime/src/main/java/com/facebook/thrift/util/SPINiftyMetrics.java
+++ b/thrift/lib/java/runtime/src/main/java/com/facebook/thrift/util/SPINiftyMetrics.java
@@ -22,7 +22,7 @@ import io.airlift.stats.ExponentialDecay;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-/** NiftyMetrics to support backward compatibile in SPI while refactoring to Netty 4 */
+/** NiftyMetrics to support backward compatible in SPI while refactoring to Netty 4 */
 @Deprecated
 public class SPINiftyMetrics implements NiftyMetrics {
   private final AtomicInteger channelCount;

--- a/thrift/lib/javadeprecated/src/main/java/com/facebook/thrift/meta_data/FieldMetaData.java
+++ b/thrift/lib/javadeprecated/src/main/java/com/facebook/thrift/meta_data/FieldMetaData.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * This class is used to store meta data about thrift fields. Every field in a a struct should have
+ * This class is used to store meta data about thrift fields. Every field in a struct should have
  * a corresponding instance of this class describing it.
  */
 @SuppressWarnings("serial")

--- a/thrift/test/OptionalsTest.cpp
+++ b/thrift/test/OptionalsTest.cpp
@@ -154,7 +154,7 @@ TEST(OptionalsTest, EqualityTests) {
   // for each of the fields:
   // * set a required field, expect equal.
   // * set an optional field on one; expect not equal.
-  // * the the optional field on the other one; equal again.
+  // * the optional field on the other one; equal again.
 
   // both completely empty
   EXPECT_EQ(obj1, obj2);

--- a/thrift/test/SerializationInFieldIdOrderTest.cpp
+++ b/thrift/test/SerializationInFieldIdOrderTest.cpp
@@ -62,7 +62,7 @@ TEST(Foo, RoundTrip) {
   EXPECT_EQ(CompactSerializer::deserialize<Foo>(s), foo);
   EXPECT_EQ(CompactSerializer::deserialize<Foo2>(s2), foo2);
 
-  // Test backward/forward compatiblity
+  // Test backward/forward compatibility
   EXPECT_EQ(CompactSerializer::deserialize<Foo>(s2), foo);
   EXPECT_EQ(CompactSerializer::deserialize<Foo2>(s), foo2);
 }

--- a/thrift/test/fuzzer/RandomizerTest.py
+++ b/thrift/test/fuzzer/RandomizerTest.py
@@ -110,7 +110,7 @@ class TestEnumRandomizer(unittest.TestCase, TestRandomizer):
 class TestIntRandomizer(TestRandomizer):
     @classmethod
     def _one_bit_flipped(cls, a, b):
-        """Return true if a and b differ at at most one bit position"""
+        """Return true if a and b differ at most one bit position"""
         diff = a ^ b  # Bits set to 1 where a and b differ
         # If diff has only one `1` bit, subtracting one will clear that bit
         # Otherwise, the most significant 1 will not be cleared


### PR DESCRIPTION
## Summary

Fixes a batch of high-confidence typos in **comments, documentation, and one flag-description string**. These are inspection-only changes — **no logic or behavior is modified**, and no generated files are touched.

Found via a duplicated-word + common-misspelling sweep over non-generated `.cpp/.h/.thrift/.py/.md/.java` sources. Care was taken to avoid false positives such as legitimate C++/Thrift tokens (e.g. `the THeader`, `the THrottle`).

## Changes

### Duplicated words

| Before | After |
| --- | --- |
| `the the structure` / `the the status` / `the the name` / `the the task` / `the the include` / `the the end` / `the the Rust` / `the the call site` / `the the optional` | `the …` |
| `a a struct` / `a a pointer` / `a a job` / `a a folly::SerialExecutor` | `a …` |
| `to to serialize` / `to to read` / `to to be sane` / `prior to to the` | `to …` |
| `with with ordinal` / `with with each` | `with …` |
| `of of idle` | `of idle` |
| `on on` (depend on) | `on` |
| `that that the seed` | `that the seed` |
| `are are the ones` | `are the ones` |
| `at at most` | `at most` |
| `to to the pext` | `to do the pext` |
| `according the the result` | `according to the result` |
| `if is is not detached` | `if it is not detached` |

### Misspellings

| Before | After |
| --- | --- |
| `intialization` / `intialized` | `initialization` / `initialized` |
| `compatiblity` / `compatibile` | `compatibility` / `compatible` |
| `yeild` | `yield` |
| `returing` | `returning` |

## Notes

- 37 files changed, 38 lines, all comments/docs/strings.
- The same `the the Rust` and `compatiblity` strings also appear in **generated** `gen-*` / `*/out/` fixtures; those were intentionally **not** edited since they are regenerated from the (now-fixed) sources.
- C++ was not built/tested for this change as it contains no compilable code changes.
