### PR TITLE
Fix Thrift dependency compilation order

### DIFF
--- a/thrift/lib/cpp2/CMakeLists.txt
+++ b/thrift/lib/cpp2/CMakeLists.txt
@@ -102,6 +102,7 @@ add_dependencies(thriftmetadata metadata-cpp2-target
   any_rep-cpp2-target
   protocol-cpp2-target
   protocol_detail-cpp2-target
+  type-cpp2-target
   type_id-cpp2-target
   type_system-cpp2-target
   schema-cpp2-target


### PR DESCRIPTION
Currently the dependency between the `any_rep` and `type` thrift libs is implicit, which on some platforms can cause the latter to be unbuilt for some targets, resulting in errors such as:
```
[239/622] Building CXX object thrift/lib/cpp2/CMakeFiles/thriftmetadata.dir/dynamic/TypeSystemTraits.cpp.o
FAILED: [code=1] thrift/lib/cpp2/CMakeFiles/thriftmetadata.dir/dynamic/TypeSystemTraits.cpp.o
/nix/store/hy2xqdbh7mw1w1yhqggfb3s1dmf89h10-gcc-wrapper-15.3.0/bin/g++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CONTEXT_DYN_LINK -DBOOST_CONTEXT_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DFMT_SHARED -DGFLAGS_IS_A_DLL=0 -DGLOG_USE_GLOG_EXPORT -DTHRIFT_HAVE_LIBSNAPPY=0 -Dthriftmetadata_EXPORTS -I/build/source/. -I/build/source/build -isystem /nix/store/dg6pgq3k8j2rj4j004h3rqks3kd3bay5-fast-float-8.2.10/include -isystem /nix/store/rh9samgza9bhdsz27g2n6afag5ch2vdg-libevent-2.1.13-dev/include -isystem /nix/store/gc8kg459z9kjzx4yg96q7vkvm4wlm4b8-xz-5.8.3-dev/include -isystem /nix/store/5ky8ppq46nrzqx5fkn6ickajvzllss3y-lz4-1.10.0-dev/include -isystem /nix/store/symmwwcz269glcxpzmlss970immizkz6-libiberty-15.3.0-dev/include/libiberty -isystem /nix/store/m4qhnwkm1n2l7hkjzr9p9i1z5f7nb6a5-libunwind-1.8.3-dev/include -O3 -DNDEBUG -std=c++20 -fPIC -fcoroutines -MD -MT thrift/lib/cpp2/CMakeFiles/thriftmetadata.dir/dynamic/TypeSystemTraits.cpp.o -MF thrift/lib/cpp2/CMakeFiles/thriftmetadata.dir/dynamic/TypeSystemTraits.cpp.o.d -o thrift/lib/cpp2/CMakeFiles/thriftmetadata.dir/dynamic/TypeSystemTraits.cpp.o -c /build/source/thrift/lib/cpp2/dynamic/TypeSystemTraits.cpp
In file included from /build/source/./thrift/lib/cpp2/type/Any.h:26,
                 from /build/source/thrift/lib/cpp2/dynamic/TypeSystemTraits.cpp:18:
/build/source/build/thrift/lib/thrift/gen-cpp2/any_rep_types.h:12:10: fatal error: thrift/lib/thrift/gen-cpp2/type_types.h: No such file or directory
   12 | #include "thrift/lib/thrift/gen-cpp2/type_types.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

See https://github.com/NixOS/nixpkgs/pull/547897.

One could explicitly declare all cross-dependencies between thrift libraries as well, but that seems like a bigger hassle to maintain. Given how things mostly work as-is, let's go with the minimum required change.